### PR TITLE
Use interfaces, and make properties virtual to allow mocking

### DIFF
--- a/Braintree/AddOnGateway.cs
+++ b/Braintree/AddOnGateway.cs
@@ -8,7 +8,7 @@ namespace Braintree
     {
         private readonly BraintreeService Service;
 
-        public AddOnGateway(BraintreeGateway gateway)
+        public AddOnGateway(IBraintreeGateway gateway)
         {
             gateway.Configuration.AssertHasAccessTokenOrKeys();
             Service = new BraintreeService(gateway.Configuration);

--- a/Braintree/Address.cs
+++ b/Braintree/Address.cs
@@ -26,22 +26,22 @@ namespace Braintree
     /// </example>
     public class Address
     {
-        public string Id { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public string FirstName { get; protected set; }
-        public string LastName { get; protected set; }
-        public string Company { get; protected set; }
-        public string StreetAddress { get; protected set; }
-        public string ExtendedAddress { get; protected set; }
-        public string Locality { get; protected set; }
-        public string Region { get; protected set; }
-        public string PostalCode { get; protected set; }
-        public string CountryCodeAlpha2 { get; protected set; }
-        public string CountryCodeAlpha3 { get; protected set; }
-        public string CountryCodeNumeric { get; protected set; }
-        public string CountryName { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual string FirstName { get; protected set; }
+        public virtual string LastName { get; protected set; }
+        public virtual string Company { get; protected set; }
+        public virtual string StreetAddress { get; protected set; }
+        public virtual string ExtendedAddress { get; protected set; }
+        public virtual string Locality { get; protected set; }
+        public virtual string Region { get; protected set; }
+        public virtual string PostalCode { get; protected set; }
+        public virtual string CountryCodeAlpha2 { get; protected set; }
+        public virtual string CountryCodeAlpha3 { get; protected set; }
+        public virtual string CountryCodeNumeric { get; protected set; }
+        public virtual string CountryName { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
 
         protected internal Address(NodeWrapper node)
         {
@@ -64,5 +64,8 @@ namespace Braintree
             CreatedAt = node.GetDateTime("created-at");
             UpdatedAt = node.GetDateTime("updated-at");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected Address() { }
     }
 }

--- a/Braintree/AddressGateway.cs
+++ b/Braintree/AddressGateway.cs
@@ -14,9 +14,9 @@ namespace Braintree
     public class AddressGateway : IAddressGateway
     {
         private readonly BraintreeService Service;
-        private readonly BraintreeGateway Gateway;
+        private readonly IBraintreeGateway Gateway;
 
-        protected internal AddressGateway(BraintreeGateway gateway)
+        protected internal AddressGateway(IBraintreeGateway gateway)
         {
             gateway.Configuration.AssertHasAccessTokenOrKeys();
             Gateway = gateway;

--- a/Braintree/AmexExpressCheckoutCard.cs
+++ b/Braintree/AmexExpressCheckoutCard.cs
@@ -4,22 +4,22 @@ namespace Braintree
 {
     public class AmexExpressCheckoutCard : PaymentMethod
     {
-        public string Token { get; protected set; }
-        public string CardType { get; protected set; }
-        public string Bin { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public string CardMemberNumber { get; protected set; }
-        public string CardMemberExpiryDate { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string SourceDescription { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Subscription[] Subscriptions { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual string CardType { get; protected set; }
+        public virtual string Bin { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual string CardMemberNumber { get; protected set; }
+        public virtual string CardMemberExpiryDate { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string SourceDescription { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Subscription[] Subscriptions { get; protected set; }
 
-        protected internal AmexExpressCheckoutCard(NodeWrapper node, BraintreeGateway gateway)
+        protected internal AmexExpressCheckoutCard(NodeWrapper node, IBraintreeGateway gateway)
         {
             Token = node.GetString("token");
             CardType = node.GetString("card-type");
@@ -43,5 +43,8 @@ namespace Braintree
                 Subscriptions[i] = new Subscription(subscriptionXmlNodes[i], gateway);
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal AmexExpressCheckoutCard() { }
     }
 }

--- a/Braintree/AmexExpressCheckoutDetails.cs
+++ b/Braintree/AmexExpressCheckoutDetails.cs
@@ -4,15 +4,15 @@ namespace Braintree
 {
     public class AmexExpressCheckoutDetails
     {
-        public string Token { get; protected set; }
-        public string CardType { get; protected set; }
-        public string Bin { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public string CardMemberNumber { get; protected set; }
-        public string CardMemberExpiryDate { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string SourceDescription { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual string CardType { get; protected set; }
+        public virtual string Bin { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual string CardMemberNumber { get; protected set; }
+        public virtual string CardMemberExpiryDate { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string SourceDescription { get; protected set; }
 
         protected internal AmexExpressCheckoutDetails(NodeWrapper node)
         {
@@ -26,5 +26,8 @@ namespace Braintree
             ImageUrl = node.GetString("image-url");
             SourceDescription = node.GetString("source-description");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal AmexExpressCheckoutDetails() { }
     }
 }

--- a/Braintree/AndroidPayCard.cs
+++ b/Braintree/AndroidPayCard.cs
@@ -4,26 +4,26 @@ namespace Braintree
 {
     public class AndroidPayCard : PaymentMethod
     {
-        public string CardType { get; protected set; }
-        public string Last4 { get; protected set; }
-        public string SourceCardType { get; protected set; }
-        public string SourceCardLast4 { get; protected set; }
-        public string SourceDescription { get; protected set; }
-        public string VirtualCardType { get; protected set; }
-        public string VirtualCardLast4 { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public string Token { get; protected set; }
-        public string GoogleTransactionId { get; protected set; }
-        public string Bin { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Subscription[] Subscriptions { get; protected set; }
+        public virtual string CardType { get; protected set; }
+        public virtual string Last4 { get; protected set; }
+        public virtual string SourceCardType { get; protected set; }
+        public virtual string SourceCardLast4 { get; protected set; }
+        public virtual string SourceDescription { get; protected set; }
+        public virtual string VirtualCardType { get; protected set; }
+        public virtual string VirtualCardLast4 { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual string GoogleTransactionId { get; protected set; }
+        public virtual string Bin { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Subscription[] Subscriptions { get; protected set; }
 
-        protected internal AndroidPayCard(NodeWrapper node, BraintreeGateway gateway)
+        protected internal AndroidPayCard(NodeWrapper node, IBraintreeGateway gateway)
         {
             CardType = node.GetString("virtual-card-type");
             VirtualCardType = node.GetString("virtual-card-type");
@@ -51,5 +51,8 @@ namespace Braintree
                 Subscriptions[i] = new Subscription(subscriptionXmlNodes[i], gateway);
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal AndroidPayCard() { }
     }
 }

--- a/Braintree/AndroidPayDetails.cs
+++ b/Braintree/AndroidPayDetails.cs
@@ -4,19 +4,19 @@ namespace Braintree
 {
     public class AndroidPayDetails
     {
-        public string Bin { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public string GoogleTransactionId { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string SourceCardLast4 { get; protected set; }
-        public string SourceCardType { get; protected set; }
-        public string SourceDescription { get; protected set; }
-        public string VirtualCardLast4 { get; protected set; }
-        public string VirtualCardType { get; protected set; }
-        public string CardType { get; protected set; }
-        public string Last4 { get; protected set; }
-        public string Token { get; protected set; }
+        public virtual string Bin { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual string GoogleTransactionId { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string SourceCardLast4 { get; protected set; }
+        public virtual string SourceCardType { get; protected set; }
+        public virtual string SourceDescription { get; protected set; }
+        public virtual string VirtualCardLast4 { get; protected set; }
+        public virtual string VirtualCardType { get; protected set; }
+        public virtual string CardType { get; protected set; }
+        public virtual string Last4 { get; protected set; }
+        public virtual string Token { get; protected set; }
 
         protected internal AndroidPayDetails(NodeWrapper node)
         {
@@ -34,5 +34,8 @@ namespace Braintree
             Last4 = node.GetString("virtual-card-last-4");
             Token = node.GetString("token");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal AndroidPayDetails() { }
     }
 }

--- a/Braintree/ApplePayCard.cs
+++ b/Braintree/ApplePayCard.cs
@@ -4,22 +4,22 @@ namespace Braintree
 {
     public class ApplePayCard : PaymentMethod
     {
-        public string CardType { get; protected set; }
-        public string Last4 { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public string Token { get; protected set; }
-        public string PaymentInstrumentName { get; protected set; }
-        public string SourceDescription { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public bool? IsExpired { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Subscription[] Subscriptions { get; protected set; }
+        public virtual string CardType { get; protected set; }
+        public virtual string Last4 { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual string PaymentInstrumentName { get; protected set; }
+        public virtual string SourceDescription { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual bool? IsExpired { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Subscription[] Subscriptions { get; protected set; }
 
-        protected internal ApplePayCard(NodeWrapper node, BraintreeGateway gateway)
+        protected internal ApplePayCard(NodeWrapper node, IBraintreeGateway gateway)
         {
             CardType = node.GetString("card-type");
             Last4 = node.GetString("last-4");
@@ -43,5 +43,8 @@ namespace Braintree
                 Subscriptions[i] = new Subscription(subscriptionXmlNodes[i], gateway);
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal ApplePayCard() { }
     }
 }

--- a/Braintree/ApplePayDetails.cs
+++ b/Braintree/ApplePayDetails.cs
@@ -4,13 +4,13 @@ namespace Braintree
 {
     public class ApplePayDetails
     {
-        public string CardType { get; protected set; }
-        public string PaymentInstrumentName { get; protected set; }
-        public string SourceDescription { get; protected set; }
-        public string CardholderName { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public string Token { get; protected set; }
+        public virtual string CardType { get; protected set; }
+        public virtual string PaymentInstrumentName { get; protected set; }
+        public virtual string SourceDescription { get; protected set; }
+        public virtual string CardholderName { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual string Token { get; protected set; }
 
         protected internal ApplePayDetails(NodeWrapper node)
         {
@@ -22,5 +22,8 @@ namespace Braintree
             ExpirationYear = node.GetString("expiration-year");
             Token = node.GetString("token");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal ApplePayDetails() { }
     }
 }

--- a/Braintree/CoinbaseAccount.cs
+++ b/Braintree/CoinbaseAccount.cs
@@ -4,18 +4,18 @@ namespace Braintree
 {
     public class CoinbaseAccount : PaymentMethod
     {
-        public string UserId { get; protected set; }
-        public string UserEmail { get; protected set; }
-        public string UserName { get; protected set; }
-        public string Token { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Subscription[] Subscriptions { get; protected set; }
+        public virtual string UserId { get; protected set; }
+        public virtual string UserEmail { get; protected set; }
+        public virtual string UserName { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Subscription[] Subscriptions { get; protected set; }
 
-        protected internal CoinbaseAccount(NodeWrapper node, BraintreeGateway gateway)
+        protected internal CoinbaseAccount(NodeWrapper node, IBraintreeGateway gateway)
         {
             UserId = node.GetString("user-id");
             UserEmail = node.GetString("user-email");
@@ -36,5 +36,8 @@ namespace Braintree
                 Subscriptions[i] = new Subscription(subscriptionXmlNodes[i], gateway);
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal CoinbaseAccount() { }
     }
 }

--- a/Braintree/CoinbaseDetails.cs
+++ b/Braintree/CoinbaseDetails.cs
@@ -4,10 +4,10 @@ namespace Braintree
 {
     public class CoinbaseDetails
     {
-        public string UserId { get; protected set; }
-        public string UserEmail { get; protected set; }
-        public string UserName { get; protected set; }
-        public string Token { get; protected set; }
+        public virtual string UserId { get; protected set; }
+        public virtual string UserEmail { get; protected set; }
+        public virtual string UserName { get; protected set; }
+        public virtual string Token { get; protected set; }
 
         protected internal CoinbaseDetails(NodeWrapper node)
         {
@@ -17,5 +17,7 @@ namespace Braintree
             Token = node.GetString("token");
         }
 
+        [Obsolete("Mock Use Only")]
+        protected internal CoinbaseDetails() { }
     }
 }

--- a/Braintree/CreditCard.cs
+++ b/Braintree/CreditCard.cs
@@ -133,35 +133,35 @@ namespace Braintree
         public static readonly string CountryOfIssuanceUnknown = "Unknown";
         public static readonly string IssuingBankUnknown = "Unknown";
 
-        public string Bin { get; protected set; }
-        public string CardholderName { get; protected set; }
-        public CreditCardCardType CardType { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public bool? IsVenmoSdk { get; protected set; }
-        public bool? IsExpired { get; protected set; }
-        public CreditCardCustomerLocation CustomerLocation { get; protected set; }
-        public string LastFour { get; protected set; }
-        public string UniqueNumberIdentifier { get; protected set; }
-        public Subscription[] Subscriptions { get; protected set; }
-        public string Token { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Address BillingAddress { get; protected set; }
-        public string ExpirationMonth { get; protected set; }
-        public string ExpirationYear { get; protected set; }
-        public CreditCardPrepaid Prepaid { get; protected set; }
-        public CreditCardPayroll Payroll { get; protected set; }
-        public CreditCardDebit Debit { get; protected set; }
-        public CreditCardCommercial Commercial { get; protected set; }
-        public CreditCardHealthcare Healthcare { get; protected set; }
-        public CreditCardDurbinRegulated DurbinRegulated { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public CreditCardVerification Verification { get; protected set; }
+        public virtual string Bin { get; protected set; }
+        public virtual string CardholderName { get; protected set; }
+        public virtual CreditCardCardType CardType { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual bool? IsVenmoSdk { get; protected set; }
+        public virtual bool? IsExpired { get; protected set; }
+        public virtual CreditCardCustomerLocation CustomerLocation { get; protected set; }
+        public virtual string LastFour { get; protected set; }
+        public virtual string UniqueNumberIdentifier { get; protected set; }
+        public virtual Subscription[] Subscriptions { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Address BillingAddress { get; protected set; }
+        public virtual string ExpirationMonth { get; protected set; }
+        public virtual string ExpirationYear { get; protected set; }
+        public virtual CreditCardPrepaid Prepaid { get; protected set; }
+        public virtual CreditCardPayroll Payroll { get; protected set; }
+        public virtual CreditCardDebit Debit { get; protected set; }
+        public virtual CreditCardCommercial Commercial { get; protected set; }
+        public virtual CreditCardHealthcare Healthcare { get; protected set; }
+        public virtual CreditCardDurbinRegulated DurbinRegulated { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual CreditCardVerification Verification { get; protected set; }
 
         private string _CountryOfIssuance;
 
-        public string CountryOfIssuance
+        public virtual string CountryOfIssuance
         {
             get
             {
@@ -178,7 +178,7 @@ namespace Braintree
 
         private string _IssuingBank;
 
-        public string IssuingBank
+        public virtual string IssuingBank
         {
             get
             {
@@ -193,7 +193,7 @@ namespace Braintree
             }
         }
 
-        public string ExpirationDate
+        public virtual string ExpirationDate
         {
             get
             {
@@ -214,7 +214,7 @@ namespace Braintree
             }
         }
 
-        protected internal CreditCard(NodeWrapper node, BraintreeGateway gateway)
+        protected internal CreditCard(NodeWrapper node, IBraintreeGateway gateway)
         {
             if (node == null) return;
 
@@ -255,7 +255,10 @@ namespace Braintree
             Verification = FindLatestVerification(verificationNodes, gateway);
         }
 
-        private CreditCardVerification FindLatestVerification(List<NodeWrapper> verificationNodes, BraintreeGateway gateway) {
+        [Obsolete("Mock Use Only")]
+        protected internal CreditCard() { }
+
+        private CreditCardVerification FindLatestVerification(List<NodeWrapper> verificationNodes, IBraintreeGateway gateway) {
             if(verificationNodes.Count > 0)
             {
                 verificationNodes.Sort(delegate(NodeWrapper first, NodeWrapper second) {

--- a/Braintree/CreditCardGateway.cs
+++ b/Braintree/CreditCardGateway.cs
@@ -15,9 +15,9 @@ namespace Braintree
     public class CreditCardGateway : ICreditCardGateway
     {
         private readonly BraintreeService service;
-        private readonly BraintreeGateway gateway;
+        private readonly IBraintreeGateway gateway;
 
-        protected internal CreditCardGateway(BraintreeGateway gateway)
+        protected internal CreditCardGateway(IBraintreeGateway gateway)
         {
             gateway.Configuration.AssertHasAccessTokenOrKeys();
             this.gateway = gateway;

--- a/Braintree/CreditCardVerification.cs
+++ b/Braintree/CreditCardVerification.cs
@@ -24,22 +24,22 @@ namespace Braintree
 
     public class CreditCardVerification
     {
-        public string AvsErrorResponseCode { get; protected set; }
-        public string AvsPostalCodeResponseCode { get; protected set; }
-        public string AvsStreetAddressResponseCode { get; protected set; }
-        public string CvvResponseCode { get; protected set; }
-        public TransactionGatewayRejectionReason GatewayRejectionReason { get; protected set; }
-        public string ProcessorResponseCode { get; protected set; }
-        public string ProcessorResponseText { get; protected set; }
-        public string MerchantAccountId { get; protected set; }
-        public VerificationStatus Status { get; protected set; }
-        public string Id { get; protected set; }
-        public Address BillingAddress { get; protected set; }
-        public CreditCard CreditCard { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public RiskData RiskData { get; protected set; }
+        public virtual string AvsErrorResponseCode { get; protected set; }
+        public virtual string AvsPostalCodeResponseCode { get; protected set; }
+        public virtual string AvsStreetAddressResponseCode { get; protected set; }
+        public virtual string CvvResponseCode { get; protected set; }
+        public virtual TransactionGatewayRejectionReason GatewayRejectionReason { get; protected set; }
+        public virtual string ProcessorResponseCode { get; protected set; }
+        public virtual string ProcessorResponseText { get; protected set; }
+        public virtual string MerchantAccountId { get; protected set; }
+        public virtual VerificationStatus Status { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual Address BillingAddress { get; protected set; }
+        public virtual CreditCard CreditCard { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual RiskData RiskData { get; protected set; }
 
-        public CreditCardVerification(NodeWrapper node, BraintreeGateway gateway)
+        public CreditCardVerification(NodeWrapper node, IBraintreeGateway gateway)
         {
             if (node == null) return;
 
@@ -66,5 +66,8 @@ namespace Braintree
                 RiskData = new RiskData(riskDataNode);
             }
         }
+        
+        [Obsolete("Mock Use Only")]
+        protected internal CreditCardVerification() { }
     }
 }

--- a/Braintree/Customer.cs
+++ b/Braintree/Customer.cs
@@ -21,26 +21,26 @@ namespace Braintree
     /// </example>
     public class Customer
     {
-        public string Id { get; protected set; }
-        public string FirstName { get; protected set; }
-        public string LastName { get; protected set; }
-        public string Company { get; protected set; }
-        public string Email { get; protected set; }
-        public string Phone { get; protected set; }
-        public string Fax { get; protected set; }
-        public string Website { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public CreditCard[] CreditCards { get; protected set; }
-        public PayPalAccount[] PayPalAccounts { get; protected set; }
-        public ApplePayCard[] ApplePayCards { get; protected set; }
-        public AndroidPayCard[] AndroidPayCards { get; protected set; }
-        public AmexExpressCheckoutCard[] AmexExpressCheckoutCards { get; protected set; }
-        public CoinbaseAccount[] CoinbaseAccounts { get; protected set; }
-        public VenmoAccount[] VenmoAccounts { get; protected set; }
-        public PaymentMethod[] PaymentMethods { get; protected set; }
-        public Address[] Addresses { get; protected set; }
-        public Dictionary<string, string> CustomFields { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual string FirstName { get; protected set; }
+        public virtual string LastName { get; protected set; }
+        public virtual string Company { get; protected set; }
+        public virtual string Email { get; protected set; }
+        public virtual string Phone { get; protected set; }
+        public virtual string Fax { get; protected set; }
+        public virtual string Website { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual CreditCard[] CreditCards { get; protected set; }
+        public virtual PayPalAccount[] PayPalAccounts { get; protected set; }
+        public virtual ApplePayCard[] ApplePayCards { get; protected set; }
+        public virtual AndroidPayCard[] AndroidPayCards { get; protected set; }
+        public virtual AmexExpressCheckoutCard[] AmexExpressCheckoutCards { get; protected set; }
+        public virtual CoinbaseAccount[] CoinbaseAccounts { get; protected set; }
+        public virtual VenmoAccount[] VenmoAccounts { get; protected set; }
+        public virtual PaymentMethod[] PaymentMethods { get; protected set; }
+        public virtual Address[] Addresses { get; protected set; }
+        public virtual Dictionary<string, string> CustomFields { get; protected set; }
         public PaymentMethod DefaultPaymentMethod
         {
             get
@@ -56,7 +56,7 @@ namespace Braintree
             }
         }
 
-        protected internal Customer(NodeWrapper node, BraintreeGateway gateway)
+        protected internal Customer(NodeWrapper node, IBraintreeGateway gateway)
         {
             if (node == null) return;
 
@@ -147,5 +147,8 @@ namespace Braintree
 
             CustomFields = node.GetDictionary("custom-fields");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal Customer() { }
     }
 }

--- a/Braintree/CustomerGateway.cs
+++ b/Braintree/CustomerGateway.cs
@@ -13,9 +13,9 @@ namespace Braintree
     public class CustomerGateway : ICustomerGateway
     {
         private readonly BraintreeService service;
-        private readonly BraintreeGateway gateway;
+        private readonly IBraintreeGateway gateway;
 
-        protected internal CustomerGateway(BraintreeGateway gateway)
+        protected internal CustomerGateway(IBraintreeGateway gateway)
         {
             gateway.Configuration.AssertHasAccessTokenOrKeys();
             this.gateway = gateway;

--- a/Braintree/Disbursement.cs
+++ b/Braintree/Disbursement.cs
@@ -18,7 +18,6 @@ namespace Braintree
 
         private IBraintreeGateway gateway;
 
-
         public Disbursement(NodeWrapper node, IBraintreeGateway gateway)
         {
             Id = node.GetString("id");

--- a/Braintree/Disbursement.cs
+++ b/Braintree/Disbursement.cs
@@ -6,19 +6,20 @@ namespace Braintree
 {
     public class Disbursement
     {
-        public string Id { get; protected set; }
-        public decimal? Amount { get; protected set; }
-        public string ExceptionMessage { get; protected set; }
-        public DateTime? DisbursementDate { get; protected set; }
-        public string FollowUpAction { get; protected set; }
-        public MerchantAccount MerchantAccount { get; protected set; }
-        public List<string> TransactionIds { get; protected set; }
-        public bool? Success { get; protected set; }
-        public bool? Retry { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual decimal? Amount { get; protected set; }
+        public virtual string ExceptionMessage { get; protected set; }
+        public virtual DateTime? DisbursementDate { get; protected set; }
+        public virtual string FollowUpAction { get; protected set; }
+        public virtual MerchantAccount MerchantAccount { get; protected set; }
+        public virtual List<string> TransactionIds { get; protected set; }
+        public virtual bool? Success { get; protected set; }
+        public virtual bool? Retry { get; protected set; }
 
-        private BraintreeGateway gateway;
+        private IBraintreeGateway gateway;
 
-        public Disbursement(NodeWrapper node, BraintreeGateway gateway)
+
+        public Disbursement(NodeWrapper node, IBraintreeGateway gateway)
         {
             Id = node.GetString("id");
             Amount = node.GetDecimal("amount");
@@ -36,7 +37,10 @@ namespace Braintree
             this.gateway = gateway;
         }
 
-        public ResourceCollection<Transaction> Transactions()
+        [Obsolete("Mock Use Only")]
+        protected internal Disbursement() { }
+
+        public virtual ResourceCollection<Transaction> Transactions()
         {
             var gateway = new TransactionGateway(this.gateway);
 

--- a/Braintree/DisbursementDetails.cs
+++ b/Braintree/DisbursementDetails.cs
@@ -6,12 +6,13 @@ namespace Braintree
 {
     public class DisbursementDetails
     {
-        public decimal? SettlementAmount { get; protected set; }
-        public string SettlementCurrencyIsoCode { get; protected set; }
-        public string SettlementCurrencyExchangeRate { get; protected set; }
-        public bool? FundsHeld { get; protected set; }
-        public bool? Success { get; protected set; }
-        public DateTime? DisbursementDate { get; protected set; }
+        public virtual decimal? SettlementAmount { get; protected set; }
+        public virtual string SettlementCurrencyIsoCode { get; protected set; }
+        public virtual string SettlementCurrencyExchangeRate { get; protected set; }
+        public virtual bool? FundsHeld { get; protected set; }
+        public virtual bool? Success { get; protected set; }
+        public virtual DateTime? DisbursementDate { get; protected set; }
+
 
         protected internal DisbursementDetails(NodeWrapper node)
         {
@@ -27,5 +28,8 @@ namespace Braintree
         {
             return DisbursementDate != null;
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal DisbursementDetails() { }
     }
 }

--- a/Braintree/Dispute.cs
+++ b/Braintree/Dispute.cs
@@ -56,17 +56,17 @@ namespace Braintree
 
     public class Dispute
     {
-        public decimal? Amount { get; protected set; }
-        public DateTime? ReceivedDate { get; protected set; }
-        public DateTime? ReplyByDate { get; protected set; }
-        public DateTime? DateOpened { get; protected set; }
-        public DateTime? DateWon { get; protected set; }
-        public DisputeReason Reason { get; protected set; }
-        public DisputeStatus Status { get; protected set; }
-        public DisputeKind Kind { get; protected set; }
-        public string CurrencyIsoCode { get; protected set; }
-        public string Id { get; protected set; }
-        public TransactionDetails TransactionDetails { get; protected set; }
+        public virtual decimal? Amount { get; protected set; }
+        public virtual DateTime? ReceivedDate { get; protected set; }
+        public virtual DateTime? ReplyByDate { get; protected set; }
+        public virtual DateTime? DateOpened { get; protected set; }
+        public virtual DateTime? DateWon { get; protected set; }
+        public virtual DisputeReason Reason { get; protected set; }
+        public virtual DisputeStatus Status { get; protected set; }
+        public virtual DisputeKind Kind { get; protected set; }
+        public virtual string CurrencyIsoCode { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual TransactionDetails TransactionDetails { get; protected set; }
 
         public Dispute(NodeWrapper node)
         {
@@ -82,5 +82,8 @@ namespace Braintree
             Id = node.GetString("id");
             TransactionDetails = new TransactionDetails(node.GetNode("transaction"));
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal Dispute() { }
     }
 }

--- a/Braintree/IAddOnGateway.cs
+++ b/Braintree/IAddOnGateway.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning diable 1591
+﻿#pragma warning disable 1591
 
 using System.Collections.Generic;
 

--- a/Braintree/IMerchantGateway.cs
+++ b/Braintree/IMerchantGateway.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning diable 1591
+﻿#pragma warning disable 1591
 
 using System;
 

--- a/Braintree/IPlanGateway.cs
+++ b/Braintree/IPlanGateway.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning diable 1591
+﻿#pragma warning disable 1591
 
 using System;
 using System.Collections.Generic;

--- a/Braintree/ISettlementBatchSummaryGateway.cs
+++ b/Braintree/ISettlementBatchSummaryGateway.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning diable 1591
+﻿#pragma warning disable 1591
 
 using System;
 

--- a/Braintree/MerchantAccount.cs
+++ b/Braintree/MerchantAccount.cs
@@ -27,13 +27,13 @@ namespace Braintree
 
     public class MerchantAccount
     {
-      public string Id { get; protected set; }
-      public string CurrencyIsoCode { get; protected set; }
-      public MerchantAccountStatus Status { get; protected set; }
-      public MerchantAccount MasterMerchantAccount { get; protected set; }
-      public MerchantAccountIndividualDetails IndividualDetails { get; protected set; }
-      public MerchantAccountBusinessDetails BusinessDetails { get; protected set; }
-      public MerchantAccountFundingDetails FundingDetails { get; protected set; }
+      public virtual string Id { get; protected set; }
+      public virtual string CurrencyIsoCode { get; protected set; }
+      public virtual MerchantAccountStatus Status { get; protected set; }
+      public virtual MerchantAccount MasterMerchantAccount { get; protected set; }
+      public virtual MerchantAccountIndividualDetails IndividualDetails { get; protected set; }
+      public virtual MerchantAccountBusinessDetails BusinessDetails { get; protected set; }
+      public virtual MerchantAccountFundingDetails FundingDetails { get; protected set; }
 
       public bool IsSubMerchant {
         get {
@@ -67,5 +67,8 @@ namespace Braintree
         else
             FundingDetails = null;
       }
+
+      [Obsolete("Mock Use Only")]
+      protected MerchantAccount() { }
     }
 }

--- a/Braintree/MerchantAccountBusinessDetails.cs
+++ b/Braintree/MerchantAccountBusinessDetails.cs
@@ -6,10 +6,10 @@ namespace Braintree
 {
     public class MerchantAccountBusinessDetails
     {
-        public string DbaName { get; protected set; }
-        public string LegalName { get; protected set; }
-        public string TaxId { get; protected set; }
-        public Address Address { get; protected set; }
+        public virtual string DbaName { get; protected set; }
+        public virtual string LegalName { get; protected set; }
+        public virtual string TaxId { get; protected set; }
+        public virtual Address Address { get; protected set; }
 
         protected internal MerchantAccountBusinessDetails(NodeWrapper node)
         {
@@ -18,5 +18,8 @@ namespace Braintree
             TaxId = node.GetString("tax-id");
             Address = new Address(node.GetNode("address"));
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal MerchantAccountBusinessDetails() { }
     }
 }

--- a/Braintree/MerchantAccountFundingDetails.cs
+++ b/Braintree/MerchantAccountFundingDetails.cs
@@ -6,12 +6,12 @@ namespace Braintree
 {
     public class MerchantAccountFundingDetails
     {
-        public FundingDestination Destination { get; protected set; }
-        public string RoutingNumber { get; protected set; }
-        public string AccountNumberLast4 { get; protected set; }
-        public string Email { get; protected set; }
-        public string MobilePhone { get; protected set; }
-        public string Descriptor { get; protected set; }
+        public virtual FundingDestination Destination { get; protected set; }
+        public virtual string RoutingNumber { get; protected set; }
+        public virtual string AccountNumberLast4 { get; protected set; }
+        public virtual string Email { get; protected set; }
+        public virtual string MobilePhone { get; protected set; }
+        public virtual string Descriptor { get; protected set; }
 
         protected internal MerchantAccountFundingDetails(NodeWrapper node)
         {
@@ -25,5 +25,8 @@ namespace Braintree
             MobilePhone = node.GetString("mobile-phone");
             Descriptor = node.GetString("descriptor");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal MerchantAccountFundingDetails() { }
     }
 }

--- a/Braintree/MerchantAccountIndividualDetails.cs
+++ b/Braintree/MerchantAccountIndividualDetails.cs
@@ -6,13 +6,13 @@ namespace Braintree
 {
     public class MerchantAccountIndividualDetails
     {
-        public string FirstName { get; protected set; }
-        public string LastName { get; protected set; }
-        public string Email { get; protected set; }
-        public string Phone { get; protected set; }
-        public string DateOfBirth { get; protected set; }
-        public string SsnLastFour { get; protected set; }
-        public Address Address { get; protected set; }
+        public virtual string FirstName { get; protected set; }
+        public virtual string LastName { get; protected set; }
+        public virtual string Email { get; protected set; }
+        public virtual string Phone { get; protected set; }
+        public virtual string DateOfBirth { get; protected set; }
+        public virtual string SsnLastFour { get; protected set; }
+        public virtual Address Address { get; protected set; }
 
         protected internal MerchantAccountIndividualDetails(NodeWrapper node)
         {
@@ -24,5 +24,8 @@ namespace Braintree
             SsnLastFour = node.GetString("ssn-last-4");
             Address = new Address(node.GetNode("address"));
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal MerchantAccountIndividualDetails() { }
     }
 }

--- a/Braintree/Modification.cs
+++ b/Braintree/Modification.cs
@@ -6,18 +6,18 @@ namespace Braintree
 {
     public class Modification
     {
-        public decimal? Amount { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public int? CurrentBillingCycle { get; protected set; }
-        public string Description { get; protected set; }
-        public string Id { get; protected set; }
-        public string Kind { get; protected set; }
-        public string MerchantId { get; protected set; }
-        public string Name { get; protected set; }
-        public bool? NeverExpires { get; protected set; }
-        public int? NumberOfBillingCycles { get; protected set; }
-        public int? Quantity { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
+        public virtual decimal? Amount { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual int? CurrentBillingCycle { get; protected set; }
+        public virtual string Description { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual string Kind { get; protected set; }
+        public virtual string MerchantId { get; protected set; }
+        public virtual string Name { get; protected set; }
+        public virtual bool? NeverExpires { get; protected set; }
+        public virtual int? NumberOfBillingCycles { get; protected set; }
+        public virtual int? Quantity { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
 
         protected Modification(NodeWrapper node)
         {
@@ -34,5 +34,8 @@ namespace Braintree
             Quantity = node.GetInteger("quantity");
             UpdatedAt = node.GetDateTime("updated-at");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected Modification() { }
     }
 }

--- a/Braintree/PartnerMerchant.cs
+++ b/Braintree/PartnerMerchant.cs
@@ -4,11 +4,11 @@ namespace Braintree
 {
     public class PartnerMerchant
     {
-        public string MerchantPublicId { get; protected set; }
-        public string PublicKey { get; protected set; }
-        public string PrivateKey { get; protected set; }
-        public string PartnerMerchantId { get; protected set; }
-        public string ClientSideEncryptionKey { get; protected set; }
+        public virtual string MerchantPublicId { get; protected set; }
+        public virtual string PublicKey { get; protected set; }
+        public virtual string PrivateKey { get; protected set; }
+        public virtual string PartnerMerchantId { get; protected set; }
+        public virtual string ClientSideEncryptionKey { get; protected set; }
 
         protected internal PartnerMerchant(NodeWrapper node)
         {
@@ -18,6 +18,9 @@ namespace Braintree
             PartnerMerchantId = node.GetString("partner-merchant-id");
             ClientSideEncryptionKey = node.GetString("client-side-encryption-key");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal PartnerMerchant() { }
     }
 }
 

--- a/Braintree/PayPalAccount.cs
+++ b/Braintree/PayPalAccount.cs
@@ -4,17 +4,17 @@ namespace Braintree
 {
     public class PayPalAccount : PaymentMethod
     {
-        public string Email { get; protected set; }
-        public string BillingAgreementId { get; protected set; }
-        public string Token { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string CustomerId { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Subscription[] Subscriptions { get; protected set; }
+        public virtual string Email { get; protected set; }
+        public virtual string BillingAgreementId { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Subscription[] Subscriptions { get; protected set; }
 
-        protected internal PayPalAccount(NodeWrapper node, BraintreeGateway gateway)
+        protected internal PayPalAccount(NodeWrapper node, IBraintreeGateway gateway)
         {
             Email = node.GetString("email");
             BillingAgreementId = node.GetString("billing-agreement-id");
@@ -33,5 +33,7 @@ namespace Braintree
             }
         }
 
+        [Obsolete("Mock Use Only")]
+        protected internal PayPalAccount() { }
     }
 }

--- a/Braintree/PayPalDetails.cs
+++ b/Braintree/PayPalDetails.cs
@@ -4,23 +4,23 @@ namespace Braintree
 {
     public class PayPalDetails
     {
-        public string PayerEmail { get; protected set; }
-        public string PaymentId { get; protected set; }
-        public string AuthorizationId { get; protected set; }
-        public string Token { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string DebugId { get; protected set; }
-        public string PayeeEmail { get; protected set; }
-        public string CustomField { get; protected set; }
-        public string PayerId { get; protected set; }
-        public string PayerFirstName { get; protected set; }
-        public string PayerLastName { get; protected set; }
-        public string SellerProtectionStatus { get; protected set; }
-        public string CaptureId { get; protected set; }
-        public string RefundId { get; protected set; }
-        public string TransactionFeeAmount { get; protected set; }
-        public string TransactionFeeCurrencyIsoCode { get; protected set; }
-        public string Description { get; protected set; }
+        public virtual string PayerEmail { get; protected set; }
+        public virtual string PaymentId { get; protected set; }
+        public virtual string AuthorizationId { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string DebugId { get; protected set; }
+        public virtual string PayeeEmail { get; protected set; }
+        public virtual string CustomField { get; protected set; }
+        public virtual string PayerId { get; protected set; }
+        public virtual string PayerFirstName { get; protected set; }
+        public virtual string PayerLastName { get; protected set; }
+        public virtual string SellerProtectionStatus { get; protected set; }
+        public virtual string CaptureId { get; protected set; }
+        public virtual string RefundId { get; protected set; }
+        public virtual string TransactionFeeAmount { get; protected set; }
+        public virtual string TransactionFeeCurrencyIsoCode { get; protected set; }
+        public virtual string Description { get; protected set; }
 
         protected internal PayPalDetails(NodeWrapper node)
         {
@@ -42,5 +42,8 @@ namespace Braintree
             TransactionFeeCurrencyIsoCode = node.GetString("transaction-fee-currency-iso-code");
             Description = node.GetString("description");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal PayPalDetails() { }
     }
 }

--- a/Braintree/PaymentMethodNonce.cs
+++ b/Braintree/PaymentMethodNonce.cs
@@ -4,11 +4,11 @@ namespace Braintree
 {
     public class PaymentMethodNonce
     {
-        public string Nonce { get; protected set; }
-        public string Type { get; protected set; }
-        public ThreeDSecureInfo ThreeDSecureInfo { get; protected set; }
+        public virtual string Nonce { get; protected set; }
+        public virtual string Type { get; protected set; }
+        public virtual ThreeDSecureInfo ThreeDSecureInfo { get; protected set; }
 
-        protected internal PaymentMethodNonce(NodeWrapper node, BraintreeGateway gateway)
+        protected internal PaymentMethodNonce(NodeWrapper node, IBraintreeGateway gateway)
         {
             Nonce = node.GetString("nonce");
             Type = node.GetString("type");
@@ -18,5 +18,8 @@ namespace Braintree
                 ThreeDSecureInfo = new ThreeDSecureInfo(threeDSecureInfoNode);
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal PaymentMethodNonce() { }
     }
 }

--- a/Braintree/Plan.cs
+++ b/Braintree/Plan.cs
@@ -14,19 +14,19 @@ namespace Braintree
 
     public class Plan
     {
-        public List<AddOn> AddOns { get; protected set; }
-        public int? BillingDayOfMonth { get; protected set; }
-        public int? BillingFrequency { get; protected set; }
-        public string CurrencyIsoCode { get; protected set; }
-        public string Description { get; protected set; }
-        public List<Discount> Discounts { get; protected set; }
-        public string Id { get; protected set; }
-        public string Name { get; protected set; }
-        public int? NumberOfBillingCycles { get; protected set; }
-        public decimal? Price { get; protected set; }
-        public bool? TrialPeriod { get; protected set; }
-        public int? TrialDuration { get; protected set; }
-        public PlanDurationUnit TrialDurationUnit { get; protected set; }
+        public virtual List<AddOn> AddOns { get; protected set; }
+        public virtual int? BillingDayOfMonth { get; protected set; }
+        public virtual int? BillingFrequency { get; protected set; }
+        public virtual string CurrencyIsoCode { get; protected set; }
+        public virtual string Description { get; protected set; }
+        public virtual List<Discount> Discounts { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual string Name { get; protected set; }
+        public virtual int? NumberOfBillingCycles { get; protected set; }
+        public virtual decimal? Price { get; protected set; }
+        public virtual bool? TrialPeriod { get; protected set; }
+        public virtual int? TrialDuration { get; protected set; }
+        public virtual PlanDurationUnit TrialDurationUnit { get; protected set; }
 
         public Plan(NodeWrapper node)
         {
@@ -54,5 +54,8 @@ namespace Braintree
                 Discounts.Add(new Discount(discountResponse));
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal Plan() { }
     }
 }

--- a/Braintree/Result.cs
+++ b/Braintree/Result.cs
@@ -28,7 +28,7 @@ namespace Braintree
         public string Message { get; protected set; }
         public T Target { get; protected set; }
 
-        public ResultImpl(NodeWrapper node, BraintreeGateway gateway)
+        public ResultImpl(NodeWrapper node, IBraintreeGateway gateway)
         {
             if (node.IsSuccess())
             {
@@ -63,7 +63,7 @@ namespace Braintree
             return Errors == null;
         }
 
-        private T newInstanceFromResponse(NodeWrapper node, BraintreeGateway gateway)
+        private T newInstanceFromResponse(NodeWrapper node, IBraintreeGateway gateway)
         {
             if (typeof(T) == typeof(Address))
             {

--- a/Braintree/RiskData.cs
+++ b/Braintree/RiskData.cs
@@ -5,8 +5,8 @@ namespace Braintree
 {
     public class RiskData
     {
-        public string id { get; protected set; }
-        public string decision { get; protected set; }
+        public virtual string id { get; protected set; }
+        public virtual string decision { get; protected set; }
 
         public RiskData(NodeWrapper node)
         {
@@ -14,6 +14,9 @@ namespace Braintree
             id = node.GetString("id");
             decision = node.GetString("decision");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal RiskData() { }
     }
 }
 

--- a/Braintree/SettlementBatchSummary.cs
+++ b/Braintree/SettlementBatchSummary.cs
@@ -17,7 +17,10 @@ namespace Braintree
             }
         }
 
-        public IList<IDictionary<string, string>> Records
+        [Obsolete("Mock Use Only")]
+        protected internal SettlementBatchSummary() { }
+
+        public virtual IList<IDictionary<string, string>> Records
         {
             get { return records; }
         }

--- a/Braintree/StatusEvent.cs
+++ b/Braintree/StatusEvent.cs
@@ -6,11 +6,11 @@ namespace Braintree
 {
     public class StatusEvent
     {
-        public decimal? Amount { get; protected set; }
-        public TransactionStatus Status { get; protected set; }
-        public DateTime? Timestamp { get; protected set; }
-        public TransactionSource Source { get; protected set; }
-        public string User { get; protected set; }
+        public virtual decimal? Amount { get; protected set; }
+        public virtual TransactionStatus Status { get; protected set; }
+        public virtual DateTime? Timestamp { get; protected set; }
+        public virtual TransactionSource Source { get; protected set; }
+        public virtual string User { get; protected set; }
 
         public StatusEvent(NodeWrapper node)
         {
@@ -22,5 +22,8 @@ namespace Braintree
             Source = (TransactionSource)CollectionUtil.Find(TransactionSource.ALL, node.GetString("transaction-source"), TransactionSource.UNRECOGNIZED);
             User = node.GetString("user");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal StatusEvent() { }
     }
 }

--- a/Braintree/Subscription.cs
+++ b/Braintree/Subscription.cs
@@ -88,38 +88,38 @@ namespace Braintree
     /// </example>
     public class Subscription
     {
-        public decimal? Balance { get; protected set; }
-        public List<AddOn> AddOns { get; protected set; }
-        public int? BillingDayOfMonth { get; protected set; }
-        public DateTime? BillingPeriodEndDate { get; protected set; }
-        public DateTime? BillingPeriodStartDate { get; protected set; }
-        public int? CurrentBillingCycle { get; protected set; }
-        public int? DaysPastDue { get; protected set; }
-        public Descriptor Descriptor { get; protected set; }
-        public List<Discount> Discounts { get; protected set; }
-        public int? FailureCount { get; protected set; }
-        public DateTime? FirstBillingDate { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public bool? HasTrialPeriod { get; protected set; }
-        public string Id { get; protected set; }
-        public bool? NeverExpires { get; protected set; }
-        public decimal? NextBillAmount { get; protected set; }
-        public DateTime? NextBillingDate { get; protected set; }
-        public decimal? NextBillingPeriodAmount { get; protected set; }
-        public int? NumberOfBillingCycles { get; protected set; }
-        public DateTime? PaidThroughDate { get; protected set; }
-        public string PaymentMethodToken { get; protected set; }
-        public string PlanId { get; protected set; }
-        public decimal? Price { get; protected set; }
-        public SubscriptionStatusEvent[] StatusHistory { get; protected set; }
-        public SubscriptionStatus Status { get; protected set; }
-        public List<Transaction> Transactions { get; protected set; }
-        public int? TrialDuration { get; protected set; }
-        public SubscriptionDurationUnit TrialDurationUnit { get; protected set; }
-        public string MerchantAccountId { get; protected set; }
+        public virtual decimal? Balance { get; protected set; }
+        public virtual List<AddOn> AddOns { get; protected set; }
+        public virtual int? BillingDayOfMonth { get; protected set; }
+        public virtual DateTime? BillingPeriodEndDate { get; protected set; }
+        public virtual DateTime? BillingPeriodStartDate { get; protected set; }
+        public virtual int? CurrentBillingCycle { get; protected set; }
+        public virtual int? DaysPastDue { get; protected set; }
+        public virtual Descriptor Descriptor { get; protected set; }
+        public virtual List<Discount> Discounts { get; protected set; }
+        public virtual int? FailureCount { get; protected set; }
+        public virtual DateTime? FirstBillingDate { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual bool? HasTrialPeriod { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual bool? NeverExpires { get; protected set; }
+        public virtual decimal? NextBillAmount { get; protected set; }
+        public virtual DateTime? NextBillingDate { get; protected set; }
+        public virtual decimal? NextBillingPeriodAmount { get; protected set; }
+        public virtual int? NumberOfBillingCycles { get; protected set; }
+        public virtual DateTime? PaidThroughDate { get; protected set; }
+        public virtual string PaymentMethodToken { get; protected set; }
+        public virtual string PlanId { get; protected set; }
+        public virtual decimal? Price { get; protected set; }
+        public virtual SubscriptionStatusEvent[] StatusHistory { get; protected set; }
+        public virtual SubscriptionStatus Status { get; protected set; }
+        public virtual List<Transaction> Transactions { get; protected set; }
+        public virtual int? TrialDuration { get; protected set; }
+        public virtual SubscriptionDurationUnit TrialDurationUnit { get; protected set; }
+        public virtual string MerchantAccountId { get; protected set; }
 
-        public Subscription(NodeWrapper node, BraintreeGateway gateway)
+        public Subscription(NodeWrapper node, IBraintreeGateway gateway)
         {
             Balance = node.GetDecimal("balance");
             BillingDayOfMonth = node.GetInteger("billing-day-of-month");
@@ -170,5 +170,7 @@ namespace Braintree
                 Transactions.Add(new Transaction(transactionResponse, gateway));
             }
         }
+
+        protected internal Subscription() { }
     }
 }

--- a/Braintree/SubscriptionStatusEvent.cs
+++ b/Braintree/SubscriptionStatusEvent.cs
@@ -6,12 +6,12 @@ namespace Braintree
 {
     public class SubscriptionStatusEvent
     {
-        public decimal? Price { get; protected set; }
-        public decimal? Balance { get; protected set; }
-        public SubscriptionStatus Status { get; protected set; }
-        public DateTime? Timestamp { get; protected set; }
-        public SubscriptionSource Source { get; protected set; }
-        public string User { get; protected set; }
+        public virtual decimal? Price { get; protected set; }
+        public virtual decimal? Balance { get; protected set; }
+        public virtual SubscriptionStatus Status { get; protected set; }
+        public virtual DateTime? Timestamp { get; protected set; }
+        public virtual SubscriptionSource Source { get; protected set; }
+        public virtual string User { get; protected set; }
 
         public SubscriptionStatusEvent(NodeWrapper node)
         {
@@ -24,5 +24,8 @@ namespace Braintree
             Source = (SubscriptionSource)CollectionUtil.Find(SubscriptionSource.ALL, node.GetString("subscription-source"), SubscriptionSource.UNRECOGNIZED);
             User = node.GetString("user");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal SubscriptionStatusEvent() { }
     }
 }

--- a/Braintree/ThreeDSecureInfo.cs
+++ b/Braintree/ThreeDSecureInfo.cs
@@ -5,10 +5,10 @@ namespace Braintree
 {
     public class ThreeDSecureInfo
     {
-        public string Status { get; protected set; }
-        public string Enrolled { get; protected set; }
-        public bool? LiabilityShifted { get; protected set; }
-        public bool? LiabilityShiftPossible { get; protected set; }
+        public virtual string Status { get; protected set; }
+        public virtual string Enrolled { get; protected set; }
+        public virtual bool? LiabilityShifted { get; protected set; }
+        public virtual bool? LiabilityShiftPossible { get; protected set; }
 
         public ThreeDSecureInfo(NodeWrapper node)
         {
@@ -19,6 +19,9 @@ namespace Braintree
             LiabilityShifted = node.GetBoolean("liability-shifted");
             LiabilityShiftPossible = node.GetBoolean("liability-shift-possible");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal ThreeDSecureInfo() { }
     }
 }
 

--- a/Braintree/Transaction.cs
+++ b/Braintree/Transaction.cs
@@ -138,68 +138,71 @@ namespace Braintree
     /// </example>
     public class Transaction
     {
-        public string Id { get; protected set; }
-        public List<AddOn> AddOns { get; protected set; }
-        public decimal? Amount { get; protected set; }
-        public string AvsErrorResponseCode { get; protected set; }
-        public string AvsPostalCodeResponseCode { get; protected set; }
-        public string AvsStreetAddressResponseCode { get; protected set; }
-        public Address BillingAddress { get; protected set; }
-        public string Channel { get; protected set; }
-        public DateTime? CreatedAt { get; protected set; }
-        public CreditCard CreditCard { get; protected set; }
-        public string CurrencyIsoCode { get; protected set; }
-        public Customer Customer { get; protected set; }
-        public string CvvResponseCode { get; protected set; }
-        public Descriptor Descriptor { get; protected set; }
-        public List<Discount> Discounts { get; protected set; }
-        public List<Dispute> Disputes { get; protected set; }
-        public TransactionGatewayRejectionReason GatewayRejectionReason { get; protected set; }
-        public string MerchantAccountId { get; protected set; }
-        public string OrderId { get; protected set; }
-        public string PlanId { get; protected set; }
-        public string ProcessorAuthorizationCode { get; protected set; }
-        public string ProcessorResponseCode { get; protected set; }
-        public string ProcessorResponseText { get; protected set; }
-        public string ProcessorSettlementResponseCode { get; protected set; }
-        public string ProcessorSettlementResponseText { get; protected set; }
-        public string AdditionalProcessorResponse { get; protected set; }
-        public string VoiceReferralNumber { get; protected set; }
-        public string PurchaseOrderNumber { get; protected set; }
-        public bool? Recurring { get; protected set; }
-        public string RefundedTransactionId { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual List<AddOn> AddOns { get; protected set; }
+        public virtual decimal? Amount { get; protected set; }
+        public virtual string AvsErrorResponseCode { get; protected set; }
+        public virtual string AvsPostalCodeResponseCode { get; protected set; }
+        public virtual string AvsStreetAddressResponseCode { get; protected set; }
+        public virtual Address BillingAddress { get; protected set; }
+        public virtual string Channel { get; protected set; }
+        public virtual DateTime? CreatedAt { get; protected set; }
+        public virtual CreditCard CreditCard { get; protected set; }
+        public virtual string CurrencyIsoCode { get; protected set; }
+        public virtual Customer Customer { get; protected set; }
+        public virtual string CvvResponseCode { get; protected set; }
+        public virtual Descriptor Descriptor { get; protected set; }
+        public virtual List<Discount> Discounts { get; protected set; }
+        public virtual List<Dispute> Disputes { get; protected set; }
+        public virtual TransactionGatewayRejectionReason GatewayRejectionReason { get; protected set; }
+        public virtual string MerchantAccountId { get; protected set; }
+        public virtual string OrderId { get; protected set; }
+        public virtual string PlanId { get; protected set; }
+        public virtual string ProcessorAuthorizationCode { get; protected set; }
+        public virtual string ProcessorResponseCode { get; protected set; }
+        public virtual string ProcessorResponseText { get; protected set; }
+        public virtual string ProcessorSettlementResponseCode { get; protected set; }
+        public virtual string ProcessorSettlementResponseText { get; protected set; }
+        public virtual string AdditionalProcessorResponse { get; protected set; }
+        public virtual string VoiceReferralNumber { get; protected set; }
+        public virtual string PurchaseOrderNumber { get; protected set; }
+        public virtual bool? Recurring { get; protected set; }
+        public virtual string RefundedTransactionId { get; protected set; }
         [Obsolete("Use Transaction.RefundIds")]
-        public string RefundId { get; protected set; }
-        public List<string> RefundIds { get; protected set; }
-        public List<string> PartialSettlementTransactionIds { get; protected set; }
-        public string AuthorizedTransactionId { get; protected set; }
-        public string SettlementBatchId { get; protected set; }
-        public Address ShippingAddress { get; protected set; }
-        public TransactionEscrowStatus EscrowStatus { get; protected set; }
-        public TransactionStatus Status { get; protected set; }
-        public StatusEvent[] StatusHistory { get; protected set; }
-        public string SubscriptionId { get; protected set; }
-        public Subscription Subscription { get; protected set; }
-        public decimal? TaxAmount { get; protected set; }
-        public bool? TaxExempt { get; protected set; }
-        public TransactionType Type { get; protected set; }
-        public DateTime? UpdatedAt { get; protected set; }
-        public Dictionary<string, string> CustomFields { get; protected set; }
-        public decimal? ServiceFeeAmount { get; protected set; }
-        public DisbursementDetails DisbursementDetails { get; protected set; }
-        public ApplePayDetails ApplePayDetails { get; protected set; }
-        public AndroidPayDetails AndroidPayDetails { get; protected set; }
-        public AmexExpressCheckoutDetails AmexExpressCheckoutDetails { get; protected set; }
-        public PayPalDetails PayPalDetails { get; protected set; }
-        public CoinbaseDetails CoinbaseDetails { get; protected set; }
-        public VenmoAccountDetails VenmoAccountDetails { get; protected set; }
-        public PaymentInstrumentType PaymentInstrumentType { get; protected set; }
-        public RiskData RiskData { get; protected set; }
-        public ThreeDSecureInfo ThreeDSecureInfo { get; protected set; }
+        public virtual string RefundId { get; protected set; }
+        public virtual List<string> RefundIds { get; protected set; }
+        public virtual List<string> PartialSettlementTransactionIds { get; protected set; }
+        public virtual string AuthorizedTransactionId { get; protected set; }
+        public virtual string SettlementBatchId { get; protected set; }
+        public virtual Address ShippingAddress { get; protected set; }
+        public virtual TransactionEscrowStatus EscrowStatus { get; protected set; }
+        public virtual TransactionStatus Status { get; protected set; }
+        public virtual StatusEvent[] StatusHistory { get; protected set; }
+        public virtual string SubscriptionId { get; protected set; }
+        public virtual Subscription Subscription { get; protected set; }
+        public virtual decimal? TaxAmount { get; protected set; }
+        public virtual bool? TaxExempt { get; protected set; }
+        public virtual TransactionType Type { get; protected set; }
+        public virtual DateTime? UpdatedAt { get; protected set; }
+        public virtual Dictionary<string, string> CustomFields { get; protected set; }
+        public virtual decimal? ServiceFeeAmount { get; protected set; }
+        public virtual DisbursementDetails DisbursementDetails { get; protected set; }
+        public virtual ApplePayDetails ApplePayDetails { get; protected set; }
+        public virtual AndroidPayDetails AndroidPayDetails { get; protected set; }
+        public virtual AmexExpressCheckoutDetails AmexExpressCheckoutDetails { get; protected set; }
+        public virtual PayPalDetails PayPalDetails { get; protected set; }
+        public virtual CoinbaseDetails CoinbaseDetails { get; protected set; }
+        public virtual VenmoAccountDetails VenmoAccountDetails { get; protected set; }
+        public virtual PaymentInstrumentType PaymentInstrumentType { get; protected set; }
+        public virtual RiskData RiskData { get; protected set; }
+        public virtual ThreeDSecureInfo ThreeDSecureInfo { get; protected set; }
 
-        private BraintreeGateway Gateway;
+        private IBraintreeGateway Gateway;
 
-        protected internal Transaction(NodeWrapper node, BraintreeGateway gateway)
+        [Obsolete("Mock Use Only")]
+        protected Transaction() { }
+
+        protected internal Transaction(NodeWrapper node, IBraintreeGateway gateway)
         {
             Gateway = gateway;
 

--- a/Braintree/TransactionDetails.cs
+++ b/Braintree/TransactionDetails.cs
@@ -4,14 +4,17 @@ namespace Braintree
 {
     public class TransactionDetails
     {
-        public string Id { get; protected set; }
-        public string Amount { get; protected set; }
+        public virtual string Id { get; protected set; }
+        public virtual string Amount { get; protected set; }
 
         protected internal TransactionDetails(NodeWrapper node)
         {
             Id = node.GetString("id");
             Amount = node.GetString("amount");
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal TransactionDetails() { }
     }
 }
 

--- a/Braintree/TransactionGateway.cs
+++ b/Braintree/TransactionGateway.cs
@@ -13,9 +13,9 @@ namespace Braintree
     public class TransactionGateway : ITransactionGateway
     {
         private readonly BraintreeService service;
-        private readonly BraintreeGateway gateway;
+        private readonly IBraintreeGateway gateway;
 
-        protected internal TransactionGateway(BraintreeGateway gateway)
+        protected internal TransactionGateway(IBraintreeGateway gateway)
         {
             gateway.Configuration.AssertHasAccessTokenOrKeys();
             this.gateway = gateway;

--- a/Braintree/UnknownPaymentMethod.cs
+++ b/Braintree/UnknownPaymentMethod.cs
@@ -4,10 +4,10 @@ namespace Braintree
 {
     public class UnknownPaymentMethod : PaymentMethod
     {
-        public string Token { get; protected set; }
-        public bool? IsDefault { get; protected set; }
-        public string ImageUrl { get; protected set; }
-        public string CustomerId { get; protected set; }
+        public virtual string Token { get; protected set; }
+        public virtual bool? IsDefault { get; protected set; }
+        public virtual string ImageUrl { get; protected set; }
+        public virtual string CustomerId { get; protected set; }
 
         public UnknownPaymentMethod(NodeWrapper node)
         {

--- a/Braintree/VenmoAccount.cs
+++ b/Braintree/VenmoAccount.cs
@@ -15,7 +15,7 @@ namespace Braintree
         public DateTime? UpdatedAt { get; protected set; }
         public Subscription[] Subscriptions { get; protected set; }
 
-        protected internal VenmoAccount(NodeWrapper node, BraintreeGateway gateway)
+        protected internal VenmoAccount(NodeWrapper node, IBraintreeGateway gateway)
         {
             Token = node.GetString("token");
             Username = node.GetString("username");
@@ -36,6 +36,9 @@ namespace Braintree
                 Subscriptions[i] = new Subscription(subscriptionXmlNodes[i], gateway);
             }
         }
+
+        [Obsolete("Mock Use Only")]
+        protected internal VenmoAccount() { }
     }
 }
 

--- a/Braintree/WebhookNotification.cs
+++ b/Braintree/WebhookNotification.cs
@@ -54,18 +54,18 @@ namespace Braintree
 
     public class WebhookNotification
     {
-        public WebhookKind Kind { get; protected set; }
-        public Subscription Subscription { get; protected set; }
-        public MerchantAccount MerchantAccount { get; protected set; }
-        public ValidationErrors Errors { get; protected set; }
-        public string Message { get; protected set; }
-        public DateTime? Timestamp { get; protected set; }
-        public Transaction Transaction { get; protected set; }
-        public Disbursement Disbursement { get; protected set; }
-        public Dispute Dispute { get; protected set; }
-        public PartnerMerchant PartnerMerchant { get; protected set; }
+        public virtual WebhookKind Kind { get; protected set; }
+        public virtual Subscription Subscription { get; protected set; }
+        public virtual MerchantAccount MerchantAccount { get; protected set; }
+        public virtual ValidationErrors Errors { get; protected set; }
+        public virtual string Message { get; protected set; }
+        public virtual DateTime? Timestamp { get; protected set; }
+        public virtual Transaction Transaction { get; protected set; }
+        public virtual Disbursement Disbursement { get; protected set; }
+        public virtual Dispute Dispute { get; protected set; }
+        public virtual PartnerMerchant PartnerMerchant { get; protected set; }
 
-        public WebhookNotification(NodeWrapper node, BraintreeGateway gateway)
+        public WebhookNotification(NodeWrapper node, IBraintreeGateway gateway)
         {
             Timestamp = node.GetDateTime("timestamp");
             Kind = (WebhookKind)CollectionUtil.Find(WebhookKind.ALL, node.GetString("kind"), WebhookKind.UNRECOGNIZED);
@@ -108,5 +108,7 @@ namespace Braintree
                 Message = WrapperNode.GetString("message");
             }
         }
+
+        protected internal WebhookNotification() { }
     }
 }


### PR DESCRIPTION
Fixes #18.

In order to allow mocking of the various services, we need to be able to generate the responses.  This has been done by:
1.  Changing the constructors to use your gateway interfaces instead of implementations
2.  Changing the protected set properties to be virtual
3.  Adding a parameterless constructor (marked as obsolete so it doesn't get used by mistake internally).