### PR TITLE
Updated HttpWebRequest - if no proxy is specified in the configuratio…

### DIFF
--- a/Braintree.Tests/ConfigurationTest.cs
+++ b/Braintree.Tests/ConfigurationTest.cs
@@ -152,7 +152,7 @@ namespace Braintree.Tests
 
         [Test]
         [Category("Unit")]
-        public void Proxy_UsesNoProxyIfNotSpecified()
+        public void Proxy_UsesDefaultProxyIfNotSpecified()
         {
             BraintreeService service = new BraintreeService(new Configuration(
                 Environment.DEVELOPMENT,

--- a/Braintree/BraintreeService.cs
+++ b/Braintree/BraintreeService.cs
@@ -91,7 +91,11 @@ namespace Braintree
                 request.Headers.Add("Accept-Encoding", "gzip");
                 request.Accept = "application/xml";
                 request.UserAgent = "Braintree .NET " + typeof(BraintreeService).Assembly.GetName().Version.ToString();
-                request.Proxy = new WebProxy(GetProxy());
+                var proxy = GetProxy();
+                if (proxy != null)
+                {
+                    request.Proxy = new WebProxy(proxy);
+                }
                 request.Method = method;
                 request.KeepAlive = false;
                 request.Timeout = 60000;


### PR DESCRIPTION
Hello, 

After updating to the latest nuget package we are experiencing connection issues due to the proxy changes. 

By default when no proxy is specified for a HttpWebRequest the proxy settings will be first taken from the application configuration file, then the local machine settings themselves. 

See the remarks section in the [MSDN documentation](https://msdn.microsoft.com/en-us/library/czdt10d3%28v=vs.110%29.aspx)

By setting the proxy to be null if no proxy is specified in the braintree configuration prevents this behavior. 

Our administrators set the proxy settings on the server itself using internet options. This change prevents them from controlling the proxy settings and has caused our integration to fail on our staging website. 