### PR TITLE
Adding async methods to BraintreeService and TransactionGateway

### DIFF
--- a/Braintree.Tests/Braintree.Tests.csproj
+++ b/Braintree.Tests/Braintree.Tests.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Braintree.Tests</RootNamespace>
     <AssemblyName>Braintree.Tests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -26,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+	<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +34,26 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+	<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug452|AnyCPU'">
+	<DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET452</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+	<TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release452|AnyCPU'">
+	<DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;NET452</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+	<TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/Braintree.sln
+++ b/Braintree.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Braintree", "Braintree\Braintree.csproj", "{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Braintree.Tests", "Braintree.Tests\Braintree.Tests.csproj", "{60234E7B-1181-4EFF-96EE-624B4524D788}"
@@ -8,17 +10,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug452|Any CPU = Debug452|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Release452|Any CPU = Release452|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Debug452|Any CPU.ActiveCfg = Debug452|Any CPU
+		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Debug452|Any CPU.Build.0 = Debug452|Any CPU
 		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Release452|Any CPU.ActiveCfg = Release452|Any CPU
+		{D0A473FA-E30B-4AF8-BB78-C1D81C9CAAB5}.Release452|Any CPU.Build.0 = Release452|Any CPU
 		{60234E7B-1181-4EFF-96EE-624B4524D788}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{60234E7B-1181-4EFF-96EE-624B4524D788}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60234E7B-1181-4EFF-96EE-624B4524D788}.Debug452|Any CPU.ActiveCfg = Debug452|Any CPU
+		{60234E7B-1181-4EFF-96EE-624B4524D788}.Debug452|Any CPU.Build.0 = Debug452|Any CPU
 		{60234E7B-1181-4EFF-96EE-624B4524D788}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60234E7B-1181-4EFF-96EE-624B4524D788}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60234E7B-1181-4EFF-96EE-624B4524D788}.Release452|Any CPU.ActiveCfg = Release452|Any CPU
+		{60234E7B-1181-4EFF-96EE-624B4524D788}.Release452|Any CPU.Build.0 = Release452|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Braintree/Braintree.csproj
+++ b/Braintree/Braintree.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Braintree</RootNamespace>
     <AssemblyName>Braintree-2.59.0</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -32,6 +31,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +43,8 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Braintree-2.59.0.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,12 +55,39 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Braintree-2.59.0.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>braintreeSgKey.pfx</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug452|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET452</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Braintree-2.59.0.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release452|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;NET452</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Braintree-2.59.0.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/Braintree/ITransactionGateway.cs
+++ b/Braintree/ITransactionGateway.cs
@@ -1,6 +1,8 @@
 ﻿#pragma warning disable 1591
 
-using System;
+#if NET452
+using System.Threading.Tasks;
+#endif
 
 namespace Braintree
 {
@@ -10,25 +12,76 @@ namespace Braintree
     public interface ITransactionGateway
     {
         Result<Transaction> CancelRelease(string id);
+#if NET452
+        Task<Result<Transaction>> CancelReleaseAsync(string id);
+#endif
         Result<Transaction> CloneTransaction(string id, TransactionCloneRequest cloneRequest);
+#if NET452
+        Task<Result<Transaction>> CloneTransactionAsync(string id, TransactionCloneRequest cloneRequest);
+#endif
         Result<Transaction> ConfirmTransparentRedirect(string queryString);
         Result<Transaction> Credit(TransactionRequest request);
+#if NET452
+        Task<Result<Transaction>> CreditAsync(TransactionRequest request);
+#endif
         string CreditTrData(TransactionRequest trData, string redirectURL);
         Transaction Find(string id);
+#if NET452
+        Task<Transaction> FindAsync(string id);
+#endif
         Result<Transaction> HoldInEscrow(string id);
+#if NET452
+        Task<Result<Transaction>> HoldInEscrowAsync(string id);
+#endif
         Result<Transaction> Refund(string id);
+#if NET452
+        Task<Result<Transaction>> RefundAsync(string id);
+#endif
         Result<Transaction> Refund(string id, decimal amount);
+#if NET452
+        Task<Result<Transaction>> RefundAsync(string id, decimal amount);
+#endif
         Result<Transaction> ReleaseFromEscrow(string id);
+#if NET452
+        Task<Result<Transaction>> ReleaseFromEscrowAsync(string id);
+#endif
         Result<Transaction> Sale(TransactionRequest request);
+#if NET452
+        Task<Result<Transaction>> SaleAsync(TransactionRequest request);
+#endif
         string SaleTrData(TransactionRequest trData, string redirectURL);
         ResourceCollection<Transaction> Search(TransactionSearchRequest query);
+#if NET452
+        Task<ResourceCollection<Transaction>> SearchAsync(TransactionSearchRequest query);
+#endif
         Result<Transaction> SubmitForPartialSettlement(string id, TransactionRequest request);
+#if NET452
+        Task<Result<Transaction>> SubmitForPartialSettlementAsync(string id, TransactionRequest request);
+#endif
         Result<Transaction> SubmitForPartialSettlement(string id, decimal amount);
+#if NET452
+        Task<Result<Transaction>> SubmitForPartialSettlementAsync(string id, decimal amount);
+#endif
         Result<Transaction> SubmitForSettlement(string id);
+#if NET452
+        Task<Result<Transaction>> SubmitForSettlementAsync(string id);
+#endif
         Result<Transaction> SubmitForSettlement(string id, decimal amount);
+#if NET452
+        Task<Result<Transaction>> SubmitForSettlementAsync(string id, decimal amount);
+#endif
         Result<Transaction> SubmitForSettlement(string id, TransactionRequest request);
+#if NET452
+        Task<Result<Transaction>> SubmitForSettlementAsync(string id, TransactionRequest request);
+#endif
         Result<Transaction> UpdateDetails(string id, TransactionRequest request);
+#if NET452
+        Task<Result<Transaction>> UpdateDetailsAsync(string id, TransactionRequest request);
+#endif
         string TransparentRedirectURLForCreate();
         Result<Transaction> Void(string id);
+#if NET452
+        Task<Result<Transaction>> VoidAsync(string id);
+#endif
     }
 }

--- a/Braintree/TransactionGateway.cs
+++ b/Braintree/TransactionGateway.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 using System.Xml;
 using Braintree.Exceptions;
 
+#if NET452
+using System.Threading.Tasks;
+#endif
+
 namespace Braintree
 {
     /// <summary>
@@ -37,6 +41,17 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> CancelReleaseAsync(string id)
+        {
+            var request = new TransactionRequest();
+
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/cancel_release", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         [Obsolete("Use gateway.TransparentRedirect.Confirm()")]
         public virtual Result<Transaction> ConfirmTransparentRedirect(string queryString)
         {
@@ -54,6 +69,17 @@ namespace Braintree
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> HoldInEscrowAsync(string id)
+        {
+            var request = new TransactionRequest();
+
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/hold_in_escrow", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
 
         public virtual string SaleTrData(TransactionRequest trData, string redirectURL)
         {
@@ -77,6 +103,16 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> CreditAsync(TransactionRequest request)
+        {
+            request.Type = TransactionType.CREDIT;
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Transaction Find(string id)
         {
             if(id == null || id.Trim().Equals(""))
@@ -87,11 +123,31 @@ namespace Braintree
             return new Transaction(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Transaction> FindAsync(string id)
+        {
+            if (id == null || id.Trim().Equals(""))
+                throw new NotFoundException();
+
+            XmlNode response = await service.GetAsync(service.MerchantPath() + "/transactions/" + id);
+
+            return new Transaction(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Result<Transaction> Refund(string id)
         {
             XmlNode response = service.Post(service.MerchantPath() + "/transactions/" + id + "/refund");
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> RefundAsync(string id)
+        {
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/refund");
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
 
         public virtual Result<Transaction> Refund(string id, decimal amount)
         {
@@ -103,6 +159,18 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> RefundAsync(string id, decimal amount)
+        {
+            var request = new TransactionRequest
+            {
+                Amount = amount
+            };
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/refund", request);
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Result<Transaction> Sale(TransactionRequest request)
         {
             request.Type = TransactionType.SALE;
@@ -110,6 +178,16 @@ namespace Braintree
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> SaleAsync(TransactionRequest request)
+        {
+            request.Type = TransactionType.SALE;
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
 
         public virtual Result<Transaction> ReleaseFromEscrow(string id)
         {
@@ -120,18 +198,48 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> ReleaseFromEscrowAsync(string id)
+        {
+            var request = new TransactionRequest();
+
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/release_from_escrow", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Result<Transaction> SubmitForSettlement(string id)
         {
             return SubmitForSettlement(id, 0);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> SubmitForSettlementAsync(string id)
+        {
+            return await SubmitForSettlementAsync(id, 0);
+        }
+#endif
+
         public virtual Result<Transaction> SubmitForSettlement(string id, decimal amount)
         {
-            var request = new TransactionRequest();
-            request.Amount = amount;
-
+            var request = new TransactionRequest
+            {
+                Amount = amount
+            };
             return SubmitForSettlement(id, request);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> SubmitForSettlementAsync(string id, decimal amount)
+        {
+            var request = new TransactionRequest
+            {
+                Amount = amount
+            };
+            return await SubmitForSettlementAsync(id, request);
+        }
+#endif
 
         public virtual Result<Transaction> SubmitForSettlement(string id, TransactionRequest request)
         {
@@ -140,6 +248,15 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> SubmitForSettlementAsync(string id, TransactionRequest request)
+        {
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/submit_for_settlement", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Result<Transaction> UpdateDetails(string id, TransactionRequest request)
         {
             XmlNode response = service.Put(service.MerchantPath() + "/transactions/" + id + "/update_details", request);
@@ -147,13 +264,34 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> UpdateDetailsAsync(string id, TransactionRequest request)
+        {
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/update_details", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Result<Transaction> SubmitForPartialSettlement(string id, decimal amount)
         {
-            var request = new TransactionRequest();
-            request.Amount = amount;
-
+            var request = new TransactionRequest
+            {
+                Amount = amount
+            };
             return SubmitForPartialSettlement(id, request);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> SubmitForPartialSettlementAsync(string id, decimal amount)
+        {
+            var request = new TransactionRequest
+            {
+                Amount = amount
+            };
+            return await SubmitForPartialSettlementAsync(id, request);
+        }
+#endif
 
         public virtual Result<Transaction> SubmitForPartialSettlement(string id, TransactionRequest request)
         {
@@ -162,12 +300,30 @@ namespace Braintree
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
+#if NET452
+        public virtual async Task<Result<Transaction>> SubmitForPartialSettlementAsync(string id, TransactionRequest request)
+        {
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/submit_for_partial_settlement", request);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
+
         public virtual Result<Transaction> Void(string id)
         {
             XmlNode response = service.Put(service.MerchantPath() + "/transactions/" + id + "/void");
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> VoidAsync(string id)
+        {
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/void");
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
 
         public virtual ResourceCollection<Transaction> Search(TransactionSearchRequest query)
         {
@@ -182,12 +338,40 @@ namespace Braintree
             }
         }
 
+#if NET452
+        public virtual async Task<ResourceCollection<Transaction>> SearchAsync(TransactionSearchRequest query)
+        {
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/transactions/advanced_search_ids", query));
+
+            if (response.GetName() == "search-results")
+            {
+                // TODO async
+                return new ResourceCollection<Transaction>(response, delegate (string[] ids) {
+                    return FetchTransactions(query, ids);
+                });
+            }
+            else
+            {
+                throw new DownForMaintenanceException();
+            }
+        }
+#endif
+
         public virtual Result<Transaction> CloneTransaction(string id, TransactionCloneRequest cloneRequest)
         {
             XmlNode response = service.Post(service.MerchantPath() + "/transactions/" + id + "/clone", cloneRequest);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
+
+#if NET452
+        public virtual async Task<Result<Transaction>> CloneTransactionAsync(string id, TransactionCloneRequest cloneRequest)
+        {
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/clone", cloneRequest);
+
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+#endif
 
         private List<Transaction> FetchTransactions(TransactionSearchRequest query, string[] ids)
         {
@@ -202,5 +386,22 @@ namespace Braintree
             }
             return transactions;
         }
+
+#if NET452
+        // TODO async delegate in ResourceCollection constructor
+        private async Task<List<Transaction>> FetchTransactionsAsync(TransactionSearchRequest query, string[] ids)
+        {
+            query.Ids.IncludedIn(ids);
+
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/transactions/advanced_search", query));
+
+            var transactions = new List<Transaction>();
+            foreach (var node in response.GetList("transaction"))
+            {
+                transactions.Add(new Transaction(node, gateway));
+            }
+            return transactions;
+        }
+#endif
     }
 }

--- a/Braintree/app.config
+++ b/Braintree/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-	<startup/></configuration>
+	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>


### PR DESCRIPTION
Added .NET 4.5.2-targeting Debug452 and Release452 configurations and
updated csproj files so target framework switches with configuration
(i.e. original .NET 2.0/3.5 targeting should remain intact with Debug
and Release configurations). 4.5.2 is the lowest framework version still
supported by Microsoft.