### PR TITLE
Support netstandard 1.3

### DIFF
--- a/src/Braintree/project.json
+++ b/src/Braintree/project.json
@@ -42,7 +42,7 @@
         "System.Web": "4.0.0.0"
       }
     },
-    "netstandard1.6": {
+    "netstandard1.3": {
       "buildOptions": {
         "define": [
           "netcore"


### PR DESCRIPTION
The lower the netstandard number, the better, as consumers using 1.3-1.6 can now use Braintree on .net core