### PR TITLE
Improve async for .NET 4.5

### DIFF
--- a/src/Braintree/AddOnGateway.cs
+++ b/src/Braintree/AddOnGateway.cs
@@ -27,7 +27,7 @@ namespace Braintree
 
         public virtual async Task<List<AddOn>> AllAsync()
         {
-            var response = new NodeWrapper(await Service.GetAsync(Service.MerchantPath() + "/add_ons"));
+            var response = new NodeWrapper(await Service.GetAsync(Service.MerchantPath() + "/add_ons").ConfigureAwait(false));
 
             var addOns = new List<AddOn>();
             foreach (var node in response.GetList("add-on"))

--- a/src/Braintree/AddressGateway.cs
+++ b/src/Braintree/AddressGateway.cs
@@ -30,7 +30,7 @@ namespace Braintree
 
         public virtual async Task<Result<Address>> CreateAsync(string customerId, AddressRequest request)
         {
-            XmlNode addressXML = await Service.PostAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses", request);
+            XmlNode addressXML = await Service.PostAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses", request).ConfigureAwait(false);
 
             return new ResultImpl<Address>(new NodeWrapper(addressXML), Gateway);
         }
@@ -44,7 +44,7 @@ namespace Braintree
 
         public virtual async Task<Result<Address>> DeleteAsync(string customerId, string id)
         {
-            XmlNode addressXML = await Service.DeleteAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses/" + id);
+            XmlNode addressXML = await Service.DeleteAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses/" + id).ConfigureAwait(false);
 
             return new ResultImpl<Address>(new NodeWrapper(addressXML), Gateway);
         }
@@ -68,7 +68,7 @@ namespace Braintree
                 throw new NotFoundException();
             }
 
-            XmlNode addressXML = await Service.GetAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses/" + id);
+            XmlNode addressXML = await Service.GetAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses/" + id).ConfigureAwait(false);
 
             return new Address(new NodeWrapper(addressXML));
         }
@@ -83,7 +83,7 @@ namespace Braintree
 
         public virtual async Task<Result<Address>> UpdateAsync(string customerId, string id, AddressRequest request)
         {
-            XmlNode addressXML = await Service.PutAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses/" + id, request);
+            XmlNode addressXML = await Service.PutAsync(Service.MerchantPath() + "/customers/" + customerId + "/addresses/" + id, request).ConfigureAwait(false);
 
             return new ResultImpl<Address>(new NodeWrapper(addressXML), Gateway);
         }

--- a/src/Braintree/Braintree.xproj
+++ b/src/Braintree/Braintree.xproj
@@ -267,6 +267,7 @@
     <Compile Include="Exceptions\TestOperationPerformedInProductionException.cs" />
     <Compile Include="Test\MerchantAccount.cs" />
     <Compile Include="WebProxy.cs" />
+    <Compile Include="WebRequestAsyncExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Braintree/BraintreeService.cs
+++ b/src/Braintree/BraintreeService.cs
@@ -67,9 +67,9 @@ namespace Braintree
             return GetXmlResponse(URL, "GET", null);
         }
 
-        public async Task<XmlNode> GetAsync(string URL)
+        public Task<XmlNode> GetAsync(string URL)
         {
-            return await GetXmlResponseAsync(URL, "GET", null);
+            return GetXmlResponseAsync(URL, "GET", null);
         }
 
         internal XmlNode Delete(string URL)
@@ -77,9 +77,9 @@ namespace Braintree
             return GetXmlResponse(URL, "DELETE", null);
         }
 
-        internal async Task<XmlNode> DeleteAsync(string URL)
+        internal Task<XmlNode> DeleteAsync(string URL)
         {
-            return await GetXmlResponseAsync(URL, "DELETE", null);
+            return GetXmlResponseAsync(URL, "DELETE", null);
         }
 
         public XmlNode Post(string URL, Request requestBody)
@@ -87,9 +87,9 @@ namespace Braintree
             return GetXmlResponse(URL, "POST", requestBody);
         }
 
-        public async Task<XmlNode> PostAsync(string URL, Request requestBody)
+        public Task<XmlNode> PostAsync(string URL, Request requestBody)
         {
-            return await GetXmlResponseAsync(URL, "POST", requestBody);
+            return GetXmlResponseAsync(URL, "POST", requestBody);
         }
 
         internal XmlNode Post(string URL)
@@ -97,9 +97,9 @@ namespace Braintree
             return Post(URL, null);
         }
 
-        internal async Task<XmlNode> PostAsync(string URL)
+        internal Task<XmlNode> PostAsync(string URL)
         {
-            return await PostAsync(URL, null);
+            return PostAsync(URL, null);
         }
 
         public XmlNode Put(string URL)
@@ -107,9 +107,9 @@ namespace Braintree
             return Put(URL, null);
         }
 
-        public async Task<XmlNode> PutAsync(string URL)
+        public Task<XmlNode> PutAsync(string URL)
         {
-            return await PutAsync(URL, null);
+            return PutAsync(URL, null);
         }
 
         internal XmlNode Put(string URL, Request requestBody)
@@ -117,9 +117,9 @@ namespace Braintree
             return GetXmlResponse(URL, "PUT", requestBody);
         }
 
-        internal async Task<XmlNode> PutAsync(string URL, Request requestBody)
+        internal Task<XmlNode> PutAsync(string URL, Request requestBody)
         {
-            return await GetXmlResponseAsync(URL, "PUT", requestBody);
+            return GetXmlResponseAsync(URL, "PUT", requestBody);
         }
 
 #if netcore
@@ -296,13 +296,13 @@ namespace Braintree
                     byte[] buffer = Encoding.UTF8.GetBytes(xmlPrefix + requestBody.ToXml());
                     request.ContentType = "application/xml";
                     request.ContentLength = buffer.Length;
-                    using (Stream requestStream = request.GetRequestStream())
+                    using (Stream requestStream = await request.GetRequestStreamAsync().ConfigureAwait(false))
                     {
-                        requestStream.Write(buffer, 0, buffer.Length);
+                        await requestStream.WriteAsync(buffer, 0, buffer.Length);
                     }
                 }
 
-                using (var response = (HttpWebResponse) request.GetResponse())
+                using (var response = (HttpWebResponse) await request.GetResponseAsync().ConfigureAwait(false))
                 {
                     return await ParseResponseStreamAsync(GetResponseStream(response));
                 }
@@ -355,7 +355,7 @@ namespace Braintree
             var stream = response.GetResponseStream();
             if (response.ContentEncoding.Equals("gzip", StringComparison.CurrentCultureIgnoreCase))
             {
-                stream = new GZipStream(response.GetResponseStream(), CompressionMode.Decompress);
+                stream = new GZipStream(stream, CompressionMode.Decompress);
             }
             return stream;
         }
@@ -377,7 +377,7 @@ namespace Braintree
             string body;
             using (var streamReader = new StreamReader(stream))
             {
-                body = await streamReader.ReadToEndAsync();
+                body = await streamReader.ReadToEndAsync().ConfigureAwait(false);
             }
 
             return StringToXmlNode(body);

--- a/src/Braintree/ClientTokenGateway.cs
+++ b/src/Braintree/ClientTokenGateway.cs
@@ -42,7 +42,7 @@ namespace Braintree
         {
             if (request == null) request = new ClientTokenRequest();
             verifyOptions(request);
-            XmlNode response = await Service.PostAsync(Service.MerchantPath() + "/client_token", request);
+            XmlNode response = await Service.PostAsync(Service.MerchantPath() + "/client_token", request).ConfigureAwait(false);
 
             if (response.Name.Equals("client-token"))
             {

--- a/src/Braintree/CreditCardGateway.cs
+++ b/src/Braintree/CreditCardGateway.cs
@@ -45,7 +45,7 @@ namespace Braintree
 
         public virtual async Task<Result<CreditCard>> CreateAsync(CreditCardRequest request)
         {
-            XmlNode creditCardXML = await service.PostAsync(service.MerchantPath() + "/payment_methods", request);
+            XmlNode creditCardXML = await service.PostAsync(service.MerchantPath() + "/payment_methods", request).ConfigureAwait(false);
 
             return new ResultImpl<CreditCard>(new NodeWrapper(creditCardXML), gateway);
         }
@@ -103,7 +103,7 @@ namespace Braintree
         {
             string queryString = string.Format("start={0:MMyyyy}&end={1:MMyyyy}", start, end);
 
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/payment_methods/all/expiring_ids?" + queryString));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/payment_methods/all/expiring_ids?" + queryString).ConfigureAwait(false));
 
             return new ResourceCollection<CreditCard>(response, delegate(string[] ids) {
                 var query = new IdsSearchRequest().
@@ -135,7 +135,7 @@ namespace Braintree
             if(token == null || token.Trim().Equals(""))
                 throw new NotFoundException();
 
-            XmlNode creditCardXML = await service.GetAsync(service.MerchantPath() + "/payment_methods/credit_card/" + token);
+            XmlNode creditCardXML = await service.GetAsync(service.MerchantPath() + "/payment_methods/credit_card/" + token).ConfigureAwait(false);
 
             return new CreditCard(new NodeWrapper(creditCardXML), gateway);
         }
@@ -158,9 +158,9 @@ namespace Braintree
             service.Delete(service.MerchantPath() + "/payment_methods/credit_card/" + token);
         }
 
-        public virtual async Task DeleteAsync(string token)
+        public virtual Task DeleteAsync(string token)
         {
-            await service.DeleteAsync(service.MerchantPath() + "/payment_methods/credit_card/" + token);
+            return service.DeleteAsync(service.MerchantPath() + "/payment_methods/credit_card/" + token);
         }
 
         public virtual Result<CreditCard> Update(string token, CreditCardRequest request)

--- a/src/Braintree/CreditCardVerificationGateway.cs
+++ b/src/Braintree/CreditCardVerificationGateway.cs
@@ -52,7 +52,7 @@ namespace Braintree
 
         public virtual async Task<ResourceCollection<CreditCardVerification>> SearchAsync(CreditCardVerificationSearchRequest query)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/verifications/advanced_search_ids", query));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/verifications/advanced_search_ids", query).ConfigureAwait(false));
 
             return new ResourceCollection<CreditCardVerification>(response, delegate(string[] ids) {
                 return FetchCreditCardVerifications(query, ids);

--- a/src/Braintree/CustomerGateway.cs
+++ b/src/Braintree/CustomerGateway.cs
@@ -38,7 +38,7 @@ namespace Braintree
             if(Id == null || Id.Trim().Equals(""))
                 throw new NotFoundException();
 
-            XmlNode customerXML = await service.GetAsync(service.MerchantPath() + "/customers/" + Id);
+            XmlNode customerXML = await service.GetAsync(service.MerchantPath() + "/customers/" + Id).ConfigureAwait(false);
 
             return new Customer(new NodeWrapper(customerXML), gateway);
         }
@@ -48,9 +48,9 @@ namespace Braintree
             return Create(new CustomerRequest());
         }
 
-        public virtual async Task<Result<Customer>> CreateAsync()
+        public virtual Task<Result<Customer>> CreateAsync()
         {
-            return await CreateAsync(new CustomerRequest());
+            return CreateAsync(new CustomerRequest());
         }
 
         public virtual Result<Customer> Create(CustomerRequest request)
@@ -62,7 +62,7 @@ namespace Braintree
 
         public virtual async Task<Result<Customer>> CreateAsync(CustomerRequest request)
         {
-            XmlNode customerXML = await service.PostAsync(service.MerchantPath() + "/customers", request);
+            XmlNode customerXML = await service.PostAsync(service.MerchantPath() + "/customers", request).ConfigureAwait(false);
 
             return new ResultImpl<Customer>(new NodeWrapper(customerXML), gateway);
         }
@@ -76,7 +76,7 @@ namespace Braintree
 
         public virtual async Task<Result<Customer>> DeleteAsync(string Id)
         {
-            XmlNode customerXML = await service.DeleteAsync(service.MerchantPath() + "/customers/" + Id);
+            XmlNode customerXML = await service.DeleteAsync(service.MerchantPath() + "/customers/" + Id).ConfigureAwait(false);
 
             return new ResultImpl<Customer>(new NodeWrapper(customerXML), gateway);
         }
@@ -90,7 +90,7 @@ namespace Braintree
 
         public virtual async Task<Result<Customer>> UpdateAsync(string Id, CustomerRequest request)
         {
-            XmlNode customerXML = await service.PutAsync(service.MerchantPath() + "/customers/" + Id, request);
+            XmlNode customerXML = await service.PutAsync(service.MerchantPath() + "/customers/" + Id, request).ConfigureAwait(false);
 
             return new ResultImpl<Customer>(new NodeWrapper(customerXML), gateway);
         }
@@ -128,7 +128,7 @@ namespace Braintree
 
         public virtual async Task<ResourceCollection<Customer>> AllAsync()
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/customers/advanced_search_ids"));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/customers/advanced_search_ids").ConfigureAwait(false));
             var query = new CustomerSearchRequest();
 
             return new ResourceCollection<Customer>(response, delegate(string[] ids) {
@@ -147,7 +147,7 @@ namespace Braintree
 
         public virtual async Task<ResourceCollection<Customer>> SearchAsync(CustomerSearchRequest query)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/customers/advanced_search_ids", query));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/customers/advanced_search_ids", query).ConfigureAwait(false));
 
             return new ResourceCollection<Customer>(response, delegate(string[] ids) {
                 return FetchCustomers(query, ids);

--- a/src/Braintree/DiscountGateway.cs
+++ b/src/Braintree/DiscountGateway.cs
@@ -27,7 +27,7 @@ namespace Braintree
 
         public virtual async Task<List<Discount>> AllAsync()
         {
-            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/discounts"));
+            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/discounts").ConfigureAwait(false));
 
             var discounts = new List<Discount>();
             foreach (var node in response.GetList("discount"))

--- a/src/Braintree/MerchantAccountGateway.cs
+++ b/src/Braintree/MerchantAccountGateway.cs
@@ -26,7 +26,7 @@ namespace Braintree
 
         public virtual async Task<Result<MerchantAccount>> CreateAsync(MerchantAccountRequest request)
         {
-            XmlNode merchantAccountXML = await service.PostAsync(service.MerchantPath() + "/merchant_accounts/create_via_api", request);
+            XmlNode merchantAccountXML = await service.PostAsync(service.MerchantPath() + "/merchant_accounts/create_via_api", request).ConfigureAwait(false);
 
             return new ResultImpl<MerchantAccount>(new NodeWrapper(merchantAccountXML), gateway);
         }
@@ -40,7 +40,7 @@ namespace Braintree
 
         public virtual async Task<Result<MerchantAccount>> CreateForCurrencyAsync(MerchantAccountCreateForCurrencyRequest request)
         {
-            XmlNode merchantAccountXML = await service.PostAsync(service.MerchantPath() + "/merchant_accounts/create_for_currency", request);
+            XmlNode merchantAccountXML = await service.PostAsync(service.MerchantPath() + "/merchant_accounts/create_for_currency", request).ConfigureAwait(false);
 
             return new ResultImpl<MerchantAccount>(new NodeWrapper(merchantAccountXML), gateway);
         }
@@ -54,7 +54,7 @@ namespace Braintree
 
         public virtual async Task<Result<MerchantAccount>> UpdateAsync(string id, MerchantAccountRequest request)
         {
-            XmlNode merchantAccountXML = await service.PutAsync(service.MerchantPath() + "/merchant_accounts/" + id + "/update_via_api", request);
+            XmlNode merchantAccountXML = await service.PutAsync(service.MerchantPath() + "/merchant_accounts/" + id + "/update_via_api", request).ConfigureAwait(false);
 
             return new ResultImpl<MerchantAccount>(new NodeWrapper(merchantAccountXML), gateway);
         }
@@ -78,7 +78,7 @@ namespace Braintree
                 throw new NotFoundException();
             }
 
-            XmlNode merchantAccountXML = await service.GetAsync(service.MerchantPath() + "/merchant_accounts/" + id);
+            XmlNode merchantAccountXML = await service.GetAsync(service.MerchantPath() + "/merchant_accounts/" + id).ConfigureAwait(false);
 
             return new MerchantAccount(new NodeWrapper(merchantAccountXML));
         }

--- a/src/Braintree/PaymentMethodGateway.cs
+++ b/src/Braintree/PaymentMethodGateway.cs
@@ -23,7 +23,7 @@ namespace Braintree
 
         public async Task<Result<PaymentMethod>> CreateAsync(PaymentMethodRequest request)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/payment_methods", request));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/payment_methods", request).ConfigureAwait(false));
             return ExtractResultFromResponse(response);
         }
 
@@ -46,7 +46,7 @@ namespace Braintree
 
         public async Task<Result<PaymentMethod>> DeleteAsync(string token)
         {
-            var response = new NodeWrapper(await service.DeleteAsync(service.MerchantPath() + "/payment_methods/any/" + token));
+            var response = new NodeWrapper(await service.DeleteAsync(service.MerchantPath() + "/payment_methods/any/" + token).ConfigureAwait(false));
             return new ResultImpl<UnknownPaymentMethod>(response, gateway);
         }
 
@@ -72,7 +72,7 @@ namespace Braintree
             if(token == null || token.Trim().Equals(""))
                 throw new NotFoundException();
 
-            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/payment_methods/any/" + token));
+            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/payment_methods/any/" + token).ConfigureAwait(false));
             return ExtractPaymentMethodFromResponse(response);
         }
 

--- a/src/Braintree/PaymentMethodNonceGateway.cs
+++ b/src/Braintree/PaymentMethodNonceGateway.cs
@@ -23,7 +23,7 @@ namespace Braintree
 
         public async Task<Result<PaymentMethodNonce>> CreateAsync(string token)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/payment_methods/" + token + "/nonces"));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/payment_methods/" + token + "/nonces").ConfigureAwait(false));
 
             return new ResultImpl<PaymentMethodNonce>(response, gateway);
         }
@@ -37,7 +37,7 @@ namespace Braintree
 
         public virtual async Task<PaymentMethodNonce> FindAsync(string nonce)
         {
-            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/payment_method_nonces/" + nonce));
+            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/payment_method_nonces/" + nonce).ConfigureAwait(false));
 
             return new PaymentMethodNonce(response, gateway);
         }

--- a/src/Braintree/PlanGateway.cs
+++ b/src/Braintree/PlanGateway.cs
@@ -27,7 +27,7 @@ namespace Braintree
 
         public virtual async Task<List<Plan>> AllAsync()
         {
-            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/plans"));
+            var response = new NodeWrapper(await service.GetAsync(service.MerchantPath() + "/plans").ConfigureAwait(false));
 
             var plans = new List<Plan>();
             foreach (var node in response.GetList("plan"))

--- a/src/Braintree/SettlementBatchSummaryGateway.cs
+++ b/src/Braintree/SettlementBatchSummaryGateway.cs
@@ -24,13 +24,13 @@ namespace Braintree
             return GetSummary(request);
         }
 
-        public async Task<Result<SettlementBatchSummary>> GenerateAsync(DateTime settlementDate)
+        public Task<Result<SettlementBatchSummary>> GenerateAsync(DateTime settlementDate)
         {
             var request = new SettlementBatchSummaryRequest
             {
                 SettlementDate = settlementDate
             };
-            return await GetSummaryAsync(request);
+            return GetSummaryAsync(request);
         }
 
         public Result<SettlementBatchSummary> Generate(DateTime settlementDate, string groupByCustomField)
@@ -43,14 +43,14 @@ namespace Braintree
             return GetSummary(request);
         }
 
-        public async Task<Result<SettlementBatchSummary>> GenerateAsync(DateTime settlementDate, string groupByCustomField)
+        public Task<Result<SettlementBatchSummary>> GenerateAsync(DateTime settlementDate, string groupByCustomField)
         {
             var request = new SettlementBatchSummaryRequest
             {
                 SettlementDate = settlementDate,
                 GroupByCustomField = groupByCustomField
             };
-            return await GetSummaryAsync(request);
+            return GetSummaryAsync(request);
         }
 
         private Result<SettlementBatchSummary> GetSummary(SettlementBatchSummaryRequest request)
@@ -61,7 +61,7 @@ namespace Braintree
 
         private async Task<Result<SettlementBatchSummary>> GetSummaryAsync(SettlementBatchSummaryRequest request)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/settlement_batch_summary", request));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/settlement_batch_summary", request).ConfigureAwait(false));
             return new ResultImpl<SettlementBatchSummary>(response, gateway);
         }
     }

--- a/src/Braintree/SubscriptionGateway.cs
+++ b/src/Braintree/SubscriptionGateway.cs
@@ -33,7 +33,7 @@ namespace Braintree
 
         public virtual async Task<Result<Subscription>> CreateAsync(SubscriptionRequest request)
         {
-            XmlNode subscriptionXML = await service.PostAsync(service.MerchantPath() + "/subscriptions", request);
+            XmlNode subscriptionXML = await service.PostAsync(service.MerchantPath() + "/subscriptions", request).ConfigureAwait(false);
 
             return new ResultImpl<Subscription>(new NodeWrapper(subscriptionXML), gateway);
         }
@@ -53,7 +53,7 @@ namespace Braintree
             if(id == null || id.Trim().Equals(""))
                 throw new NotFoundException();
 
-            XmlNode subscriptionXML = await service.GetAsync(service.MerchantPath() + "/subscriptions/" + id);
+            XmlNode subscriptionXML = await service.GetAsync(service.MerchantPath() + "/subscriptions/" + id).ConfigureAwait(false);
 
             return new Subscription(new NodeWrapper(subscriptionXML), gateway);
         }
@@ -67,7 +67,7 @@ namespace Braintree
 
         public virtual async Task<Result<Subscription>> UpdateAsync(string id, SubscriptionRequest request)
         {
-            XmlNode subscriptionXML = await service.PutAsync(service.MerchantPath() + "/subscriptions/" + id, request);
+            XmlNode subscriptionXML = await service.PutAsync(service.MerchantPath() + "/subscriptions/" + id, request).ConfigureAwait(false);
 
             return new ResultImpl<Subscription>(new NodeWrapper(subscriptionXML), gateway);
         }
@@ -81,7 +81,7 @@ namespace Braintree
 
         public virtual async Task<Result<Subscription>> CancelAsync(string id)
         {
-            XmlNode subscriptionXML = await service.PutAsync(service.MerchantPath() + "/subscriptions/" + id + "/cancel");
+            XmlNode subscriptionXML = await service.PutAsync(service.MerchantPath() + "/subscriptions/" + id + "/cancel").ConfigureAwait(false);
 
             return new ResultImpl<Subscription>(new NodeWrapper(subscriptionXML), gateway);
         }
@@ -111,7 +111,7 @@ namespace Braintree
 
         public virtual async Task<ResourceCollection<Subscription>> SearchAsync(SubscriptionSearchRequest query)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/subscriptions/advanced_search_ids", query));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/subscriptions/advanced_search_ids", query).ConfigureAwait(false));
 
             return new ResourceCollection<Subscription>(response, delegate(string[] ids) {
                 return FetchSubscriptions(query, ids);
@@ -145,7 +145,7 @@ namespace Braintree
         }
 
         private async Task<Result<Transaction>> RetryChargeAsync(SubscriptionTransactionRequest txnRequest) {
-            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", txnRequest);
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", txnRequest).ConfigureAwait(false);
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
@@ -156,8 +156,8 @@ namespace Braintree
             });
         }
 
-        public async Task<Result<Transaction>> RetryChargeAsync(string subscriptionId) {
-            return await RetryChargeAsync(new SubscriptionTransactionRequest
+        public Task<Result<Transaction>> RetryChargeAsync(string subscriptionId) {
+            return RetryChargeAsync(new SubscriptionTransactionRequest
             {
                 SubscriptionId = subscriptionId
             });
@@ -171,8 +171,8 @@ namespace Braintree
             });
         }
 
-        public async Task<Result<Transaction>> RetryChargeAsync(string subscriptionId, decimal amount) {
-            return await RetryChargeAsync(new SubscriptionTransactionRequest
+        public Task<Result<Transaction>> RetryChargeAsync(string subscriptionId, decimal amount) {
+            return RetryChargeAsync(new SubscriptionTransactionRequest
             {
                 SubscriptionId = subscriptionId,
                 Amount = amount

--- a/src/Braintree/TestTransactionGateway.cs
+++ b/src/Braintree/TestTransactionGateway.cs
@@ -38,7 +38,7 @@ namespace Braintree
         public virtual async Task<Transaction> SettleAsync(string id)
         {
             CheckEnvironment();
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/settle");
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/settle").ConfigureAwait(false);
             return new Transaction(new NodeWrapper(response), gateway);
         }
 
@@ -52,7 +52,7 @@ namespace Braintree
         public virtual async Task<Transaction> SettlementConfirmAsync(string id)
         {
             CheckEnvironment();
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/settlement_confirm");
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/settlement_confirm").ConfigureAwait(false);
             return new Transaction(new NodeWrapper(response), gateway);
         }
 
@@ -73,7 +73,7 @@ namespace Braintree
         public virtual async Task<Transaction> SettlementDeclineAsync(string id)
         {
             CheckEnvironment();
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/settlement_decline");
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/settlement_decline").ConfigureAwait(false);
             return new Transaction(new NodeWrapper(response), gateway);
         }
     }

--- a/src/Braintree/TransactionGateway.cs
+++ b/src/Braintree/TransactionGateway.cs
@@ -42,7 +42,7 @@ namespace Braintree
         {
             var request = new TransactionRequest();
 
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/cancel_release", request);
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/cancel_release", request).ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
@@ -69,7 +69,7 @@ namespace Braintree
         {
             var request = new TransactionRequest();
 
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/hold_in_escrow", request);
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/hold_in_escrow", request).ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
@@ -99,7 +99,7 @@ namespace Braintree
         public virtual async Task<Result<Transaction>> CreditAsync(TransactionRequest request)
         {
             request.Type = TransactionType.CREDIT;
-            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", request);
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", request).ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
@@ -119,7 +119,7 @@ namespace Braintree
             if(id == null || id.Trim().Equals(""))
                 throw new NotFoundException();
 
-            XmlNode response = await service.GetAsync(service.MerchantPath() + "/transactions/" + id);
+            XmlNode response = await service.GetAsync(service.MerchantPath() + "/transactions/" + id).ConfigureAwait(false);
 
             return new Transaction(new NodeWrapper(response), gateway);
         }
@@ -132,7 +132,7 @@ namespace Braintree
 
         public virtual async Task<Result<Transaction>> RefundAsync(string id)
         {
-            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/refund");
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/refund").ConfigureAwait(false);
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
@@ -146,14 +146,14 @@ namespace Braintree
             return Refund(id, request);
         }
 
-        public virtual async Task<Result<Transaction>> RefundAsync(string id, decimal amount)
+        public virtual Task<Result<Transaction>> RefundAsync(string id, decimal amount)
         {
             var request = new TransactionRefundRequest
             {
                 Amount = amount
             };
 
-            return await RefundAsync(id, request);
+            return RefundAsync(id, request);
         }
 
         public virtual Result<Transaction> Refund(string id, TransactionRefundRequest refundRequest)
@@ -164,7 +164,7 @@ namespace Braintree
 
         public virtual async Task<Result<Transaction>> RefundAsync(string id, TransactionRefundRequest refundRequest)
         {
-            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/refund", refundRequest);
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/refund", refundRequest).ConfigureAwait(false);
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
@@ -179,7 +179,7 @@ namespace Braintree
         public virtual async Task<Result<Transaction>> SaleAsync(TransactionRequest request)
         {
             request.Type = TransactionType.SALE;
-            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", request);
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions", request).ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
@@ -197,7 +197,7 @@ namespace Braintree
         {
             var request = new TransactionRequest();
 
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/release_from_escrow", request);
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/release_from_escrow", request).ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
@@ -207,9 +207,9 @@ namespace Braintree
             return SubmitForSettlement(id, 0);
         }
 
-        public virtual async Task<Result<Transaction>> SubmitForSettlementAsync(string id)
+        public virtual Task<Result<Transaction>> SubmitForSettlementAsync(string id)
         {
-            return await SubmitForSettlementAsync(id, 0);
+            return SubmitForSettlementAsync(id, 0);
         }
 
         public virtual Result<Transaction> SubmitForSettlement(string id, decimal amount)
@@ -229,7 +229,7 @@ namespace Braintree
                 Amount = amount
             };
 
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/submit_for_settlement", request);
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/submit_for_settlement", request).ConfigureAwait(false);
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 
@@ -271,7 +271,7 @@ namespace Braintree
 
         public virtual async Task<Result<Transaction>> VoidAsync(string id)
         {
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/void");
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/void").ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
@@ -294,7 +294,7 @@ namespace Braintree
 
         public virtual async Task<ResourceCollection<Transaction>> SearchAsync(TransactionSearchRequest query)
         {
-            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/transactions/advanced_search_ids", query));
+            var response = new NodeWrapper(await service.PostAsync(service.MerchantPath() + "/transactions/advanced_search_ids", query).ConfigureAwait(false));
 
             if (response.GetName() == "search-results")
             {
@@ -317,7 +317,7 @@ namespace Braintree
 
         public virtual async Task<Result<Transaction>> CloneTransactionAsync(string id, TransactionCloneRequest cloneRequest)
         {
-            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/clone", cloneRequest);
+            XmlNode response = await service.PostAsync(service.MerchantPath() + "/transactions/" + id + "/clone", cloneRequest).ConfigureAwait(false);
 
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }

--- a/src/Braintree/WebRequestAsyncExtensions.cs
+++ b/src/Braintree/WebRequestAsyncExtensions.cs
@@ -1,0 +1,23 @@
+﻿#if net452
+
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Braintree
+{
+    public static class WebRequestAsyncExtensions
+    {
+        public static Task<Stream> GetRequestStreamAsync(this WebRequest request)
+        {
+            return Task.Factory.FromAsync(request.BeginGetRequestStream, request.EndGetRequestStream, null);
+        }
+
+        public static Task<WebResponse> GetResponseAsync(this WebRequest request)
+        {
+            return Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This pull request improves the implementation of the asynchronous operations for .NET 4.5 in the following ways:

- Use [ConfigureAwait(false)](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.configureawait(v=vs.110).aspx) 
- Remove `async` `await` overhead when they are not necessary
- Use [HttpWebRequest.BeginGetRequestStream](https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.begingetrequeststream(v=vs.110).aspx), [HttpWebRequest.BeginGetResponse](https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.begingetresponse(v=vs.110).aspx) and [Stream.WriteAsync](https://msdn.microsoft.com/en-us/library/system.io.stream.writeasync(v=vs.110).aspx)