### PR TITLE
Fix blocking in HttpService for .net core async method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  * Fix blocking in HttpService for .net core async methods
+
 ## 4.17.0
 - Add `RefundAuthHardDeclined` and `RefundAuthSoftDeclined` to validation errors
 - Add `PROCESSOR_DOES_NOT_SUPPORT_MOTO_FOR_CARD_TYPE` to validation errors

--- a/src/Braintree/HttpService.cs
+++ b/src/Braintree/HttpService.cs
@@ -104,13 +104,13 @@ namespace Braintree
         }
 
         public async Task<string> GetHttpResponseWithClientAsync(HttpClient client, HttpRequestMessage request) {
-            var response = client.SendAsync(request).GetAwaiter().GetResult();
+            var response = await client.SendAsync(request);
             if (response.StatusCode != (HttpStatusCode) 422)
             {
                 ThrowExceptionIfErrorStatusCode(response.StatusCode, null);
             }
 
-            return await ParseResponseStreamAsync(response.Content.ReadAsStreamAsync().GetAwaiter().GetResult());
+            return await ParseResponseStreamAsync(await response.Content.ReadAsStreamAsync());
         }
 
         public string GetHttpResponse(HttpRequestMessage request) {


### PR DESCRIPTION
# Summary

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (See README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
