### PR TITLE
Added overload on async method to include transaction request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- Add overload on `SubmitForSettlementAsync` method to include `TransactionRequest`
+
 ## 5.3.0
 - Add `scaExemption` to `Transaction`
 - Deprecate `DeviceSessionId` and `FraudMerchantId` in the `CreditCardRequest` and `TransactionRequest` classes

--- a/src/Braintree/ITransactionGateway.cs
+++ b/src/Braintree/ITransactionGateway.cs
@@ -37,6 +37,7 @@ namespace Braintree
         Task<Result<Transaction>> SubmitForSettlementAsync(string id);
         Result<Transaction> SubmitForSettlement(string id, decimal amount);
         Task<Result<Transaction>> SubmitForSettlementAsync(string id, decimal amount);
+        Task<Result<Transaction>> SubmitForSettlementAsync(string id, TransactionRequest request);
         Result<Transaction> SubmitForSettlement(string id, TransactionRequest request);
         Result<Transaction> UpdateDetails(string id, TransactionRequest request);
         Result<Transaction> Void(string id);

--- a/src/Braintree/TransactionGateway.cs
+++ b/src/Braintree/TransactionGateway.cs
@@ -200,14 +200,19 @@ namespace Braintree
                 Amount = amount
             };
 
-            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/submit_for_settlement", request).ConfigureAwait(false);
-            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+            return await SubmitForSettlementAsync(id, request);
         }
 
         public virtual Result<Transaction> SubmitForSettlement(string id, TransactionRequest request)
         {
             XmlNode response = service.Put(service.MerchantPath() + "/transactions/" + id + "/submit_for_settlement", request);
 
+            return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
+        }
+
+        public virtual async Task<Result<Transaction>> SubmitForSettlementAsync(string id, TransactionRequest request)
+        {
+            XmlNode response = await service.PutAsync(service.MerchantPath() + "/transactions/" + id + "/submit_for_settlement", request).ConfigureAwait(false);
             return new ResultImpl<Transaction>(new NodeWrapper(response), gateway);
         }
 


### PR DESCRIPTION
# Summary
If you need to pass the OrderId on the Submit For Settlement (by supplying a TransactionRequest) there was no async method for this. There is an example in the documents here: https://developers.braintreepayments.com/reference/request/transaction/submit-for-settlement/dotnet#specifying-order-id
 
# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (See README for instructions)
