### PR TITLE
Cross target .NETCOREAPP3.1 to remove transient dependencies

### DIFF
--- a/src/Braintree/Braintree.csproj
+++ b/src/Braintree/Braintree.csproj
@@ -6,8 +6,8 @@
     <Copyright>Copyright © Braintree, a division of PayPal, Inc. 2021</Copyright>
     <VersionPrefix>5.4.0</VersionPrefix>
     <Authors>Braintree</Authors>
-    <!-- We target NET standard 2.0 so that we can support NET Core 2.1. When NET Core 2.1 reaches EOL, we can update to Net Standard 2.1 -->
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <!-- We target NET standard 2.0 so that we can support NET Core 2.1. When NET Core 2.1 reaches EOL in August of 2021, we can update to Net Standard 2.1 -->
+    <TargetFrameworks>net452;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Braintree</AssemblyName>
     <PackageId>Braintree</PackageId>
     <PackageTags>braintree;paypal;venmo;intenational;payments;gateway;currencies;money;visa;mastercard;bitcoin;maestro;apple pay;android pay;amex;jcb;diners club;discover;american express</PackageTags>
@@ -44,12 +44,16 @@
     <DefineConstants>$(DefineConstants);net452</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net452' ">
     <DefineConstants>$(DefineConstants);netcore</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
# Summary

# Checklist

- [ ] Added changelog entry
- [x] Ran unit tests (See README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->

This PR cross targets .NETCOREAPP3.1 and conditionally upgrades Newtonsoft.Json to avoid bringing in any additional dependencies or facades on modern runtimes.  
