### PR TITLE
Improve handling of Unprocessable Entity (422) HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.11.0
+* Improve handling of Unprocessable Entity (422) HTTP errors
+
 ## 5.10.0
 * Add plan create/update/find API endpoint
 * Add `TransactionReview` webhook notification support

--- a/src/Braintree/Exceptions/UnexpectedException.cs
+++ b/src/Braintree/Exceptions/UnexpectedException.cs
@@ -4,5 +4,7 @@ namespace Braintree.Exceptions
 {
     public class UnexpectedException : BraintreeException
     {
+        public UnexpectedException() : base() { }
+        public UnexpectedException(string message) : base(message) { }
     }
 }

--- a/src/Braintree/Exceptions/UnprocessableEntityException.cs
+++ b/src/Braintree/Exceptions/UnprocessableEntityException.cs
@@ -1,0 +1,7 @@
+﻿namespace Braintree.Exceptions
+{
+    public class UnprocessableEntityException : BraintreeException
+    {
+        public UnprocessableEntityException(string message) : base(message) { }
+    }
+}


### PR DESCRIPTION
The code previously tried to ignore HTTP 422 errors, but the response would not be parsed correctly later on.

# Summary
The below narrative is related to the .NET Core code.  Line numbers would differ with .NET Framework.  I have improved both .NET Core and .NET Framework code in this pull request.
When making a call to `BraintreeGateway.Subscription.Search(SubscriptionSearchRequest query)` with a complex `query`, I'm getting an `System.ArgumentNullException` with this message:  "Value cannot be null. (Parameter 's')"
Here is the stack trace:
```
at System.Int32.Parse(String s)
at Braintree.ResourceCollection`1..ctor(NodeWrapper response, PagingDelegate nextPage)
at Braintree.SubscriptionGateway.Search(SubscriptionSearchRequest query)
```

Using the braintree_dotnet source code, I debugged the problem further:
1.  `SubscriptionGateway.Search` calls `BraintreeService.Post` on line 105.
2.  `BraintreeService.Post` calls `BraintreeService.GetXmlResponse` on line 48.
3.  `BraintreeService.GetXmlResponse` calls `HttpService.GetHttpResponse` on line 142.  (`GetXmlResponse` also has an unneeded and detrimental try-catch since it is catching and rethrowing an exception, but I did not change that now since I didn't want to include unnecessary changes with my pull request.)
4.  `HttpService.GetHttpResponse` calls `HttpClient.SendAsync` on line 95.
5.  Still in `HttpService.GetHttpResponse`, `response` returns with a `StatusCode` of 422.  I contend this should throw an exception so the code can fail fast.  But instead the code overlooks 422 status codes on line 96.
6.  After returning from `HttpService.GetHttpResponse`, `BraintreeService.GetXmlResponse` has a `response` of the below value on line 142:
`<unprocessable-entity><reason>timeout</reason></unprocessable-entity>`
7.  `BraintreeService.GetXmlResponse` calls `BraintreeService.StringToXmlNode` with the above value, turning the above string in an `XmlNode`.
8.  This `XmlNode` is returned to `BraintreeService.Post` and then to `SubscriptionGateway.Search`, which passes it into `new ResourceCollection<Subscription>` on line 107.
9.  `ResourceCollection<T>`'s constructor calls `int.Parse(response.GetString("page-size"))` on line 25.  
10.  `NodeWrapper.GetString` returns returns null (since "page-size" doesn't exist in the XML).  (It might be better to throw exceptions for non-existent XML values.  Again, fail fast.)
11.  `int.Parse` tries to parse a null value and fails, as in the exception listed at the top of this issue.

### Resolution

My suggestion is that the code should not try to overlook a 422 status code in `HttpService.GetHttpResponse` and `HttpService.GetHttpResponseAsync`.  Instead, I would recommend these methods be written as in my pull request.

### Server considerations

Finally, while I think the code changes would be helpful, I'm not certain the server is replying properly.  It's replying with a 422 status code (unprocessable entity), but the response body says it was an unprocessable entity because of a timeout.  I would think the server would just send a 408 (request timeout) status code, but maybe there is a good reason internally why the 428 status code is more correct.

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (See README for instructions)